### PR TITLE
= kamon-akka: cross build for Scala 2.12

### DIFF
--- a/kamon-akka-2.4.x/src/test/resources/application.conf
+++ b/kamon-akka-2.4.x/src/test/resources/application.conf
@@ -1,6 +1,7 @@
 akka {
   loglevel = INFO
   loggers = [ "akka.event.slf4j.Slf4jLogger" ]
+  logger-startup-timeout = 30s
 }
 
 kamon.metric {
@@ -59,5 +60,6 @@ tracked-tpe {
     core-pool-size-factor = 100.0
     max-pool-size-factor  = 100.0
     max-pool-size-max = 21
+    core-pool-size-max = 21
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,6 +14,7 @@
  */
 
 import sbt._
+import sbt.Keys._
 
 object Dependencies {
 
@@ -22,17 +23,16 @@ object Dependencies {
     "Kamon Repository Snapshots" at "http://snapshots.kamon.io"
   )
 
-  val kamonVersion      = "0.6.3"
-  val aspectjVersion    = "1.8.9"
+  val aspectjVersion      = "1.8.10"
+  val kamonVersion        = "0.6.5"
 
-  val akka23Version       = "2.3.13"
+  val akka23Version       = "2.3.16"
   val akka24Version       = "2.4.14"
 
   val aspectJ             = "org.aspectj"                 %   "aspectjweaver"         % aspectjVersion
 
   val kamonCore           = "io.kamon"                    %%  "kamon-core"            % kamonVersion
   val kamonScala          = "io.kamon"                    %%  "kamon-scala"           % kamonVersion
-  val kamonTestkit        = "io.kamon"                    %%  "kamon-testkit"         % kamonVersion
 
   val akkaActor23         = "com.typesafe.akka"           %%  "akka-actor"            % akka23Version
   val akkaSlf4j23         = "com.typesafe.akka"           %%  "akka-slf4j"            % akka23Version
@@ -42,8 +42,8 @@ object Dependencies {
   val akkaSlf4j24         = "com.typesafe.akka"           %%  "akka-slf4j"            % akka24Version
   val akkaTestKit24       = "com.typesafe.akka"           %%  "akka-testkit"          % akka24Version
 
-  val scalatest           = "org.scalatest"               %%  "scalatest"             % "2.2.4"
-  val logback             = "ch.qos.logback"              %   "logback-classic"       % "1.0.13"
+  val scalatest           = "org.scalatest"               %%  "scalatest"             % "3.0.1"
+  val logback             = "ch.qos.logback"              %   "logback-classic"       % "1.1.8"
 
   def compileScope   (deps: ModuleID*): Seq[ModuleID] = deps map (_ % "compile")
   def providedScope  (deps: ModuleID*): Seq[ModuleID] = deps map (_ % "provided")

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -25,10 +25,10 @@ import scalariform.formatter.preferences._
 object Settings {
 
   val JavaVersion = "1.6"
-  val SVersion = "2.11.8"
+  val SVersion = "2.12.1"
 
-  val crossVersionAkka23 = Seq("2.10.5", SVersion)
-  val crossVersionAkka24 = Seq("2.10.5", SVersion, "2.12.0")
+  val crossVersionAkka23 = Seq("2.10.5", "2.11.8")
+  val crossVersionAkka24 = Seq("2.11.8", SVersion)
 
   lazy val basicSettings = Seq(
     ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) },
@@ -46,13 +46,10 @@ object Settings {
       "-g:vars",
       "-feature",
       "-unchecked",
-      "-optimise",
       "-deprecation",
-      "-target:jvm-1.6",
       "-language:postfixOps",
-      "-language:implicitConversions",
-      "-Yinline-warnings",
-      "-Xlog-reflective-calls"
+      "-Xlog-reflective-calls",
+      "-language:implicitConversions"
     )) ++ publishSettings ++ releaseSettings
 
 

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -3,7 +3,7 @@
 # Adapted from https://github.com/paulp/psp-std/blob/master/bin/test
 
 runTests () {
-  sbt "project kamon-akka-23" test && sbt "project kamon-akka-24" test || exit 1
+  sbt "project kamon-akka-23" +test && sbt "project kamon-akka-24" +test || exit 1
 
   echo "[info] $(date) - finished sbt test"
 }


### PR DESCRIPTION
I'm not entirely fond of the binary compatibility workaround in `ActorInstrumentation` but this is at least a working cross-build. 