### PR TITLE
clear entity recorders on actor terminate instead of stop, align replaceWith advice

### DIFF
--- a/kamon-akka-2.3.x/src/main/scala/kamon/akka/instrumentation/ActorInstrumentation.scala
+++ b/kamon-akka-2.3.x/src/main/scala/kamon/akka/instrumentation/ActorInstrumentation.scala
@@ -44,6 +44,19 @@ class ActorCellInstrumentation {
     actorInstrumentation(cell).processMessage(pjp, envelope.asInstanceOf[InstrumentedEnvelope].envelopeContext())
   }
 
+  @Pointcut("execution(* akka.actor.ActorCell.terminate()) && this(cell)")
+  def callTerminate(cell: Cell) = {}
+
+  @Before("callTerminate(cell)")
+  def beforeSystemInvoke(cell: Cell): Unit = {
+    actorInstrumentation(cell).cleanup()
+
+    if (cell.isInstanceOf[RoutedActorCell]) {
+      cell.asInstanceOf[RouterInstrumentationAware].routerInstrumentation.cleanup()
+    }
+  }
+
+
   /**
    *
    *
@@ -102,23 +115,6 @@ class ActorCellInstrumentation {
       } finally {
         unStartedCell.self.swapCell(cell)
       }
-    }
-  }
-
-  /**
-   *
-   */
-
-  @Pointcut("execution(* akka.actor.ActorCell.stop()) && this(cell)")
-  def actorStop(cell: ActorCell): Unit = {}
-
-  @After("actorStop(cell)")
-  def afterStop(cell: ActorCell): Unit = {
-    actorInstrumentation(cell).cleanup()
-
-    // The Stop can't be captured from the RoutedActorCell so we need to put this piece of cleanup here.
-    if (cell.isInstanceOf[RoutedActorCell]) {
-      cell.asInstanceOf[RouterInstrumentationAware].routerInstrumentation.cleanup()
     }
   }
 

--- a/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/ActorInstrumentation.scala
+++ b/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/ActorInstrumentation.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.locks.ReentrantLock
 
 import akka.actor._
 import akka.dispatch.Envelope
-import akka.dispatch.sysmsg.SystemMessage
+import akka.dispatch.sysmsg.{LatestFirstSystemMessageList, SystemMessage, SystemMessageList}
 import akka.routing.RoutedActorCell
 import kamon.trace.Tracer
 import org.aspectj.lang.ProceedingJoinPoint
@@ -45,6 +45,18 @@ class ActorCellInstrumentation {
     actorInstrumentation(cell).processMessage(pjp, envelope.asInstanceOf[InstrumentedEnvelope].envelopeContext())
   }
 
+  @Pointcut("execution(* akka.actor.ActorCell.terminate()) && this(cell)")
+  def callTerminate(cell: Cell) = {}
+
+  @Before("callTerminate(cell)")
+  def beforeSystemInvoke(cell: Cell): Unit = {
+    actorInstrumentation(cell).cleanup()
+
+    if (cell.isInstanceOf[RoutedActorCell]) {
+      cell.asInstanceOf[RouterInstrumentationAware].routerInstrumentation.cleanup()
+    }
+  }
+
   /**
    *
    *
@@ -80,43 +92,44 @@ class ActorCellInstrumentation {
     // TODO: Find a way to do this without resorting to reflection and, even better, without copy/pasting the Akka Code!
     val queue = unstartedCellQueueField.get(unStartedCell).asInstanceOf[java.util.LinkedList[_]]
     val lock = unstartedCellLockField.get(unStartedCell).asInstanceOf[ReentrantLock]
+    var sysQueueHead = systemMsgQueueField.get(unStartedCell).asInstanceOf[SystemMessage]
 
     def locked[T](body: ⇒ T): T = {
       lock.lock()
       try body finally lock.unlock()
     }
 
+    var sysQueue =  new LatestFirstSystemMessageList(sysQueueHead)
+
     locked {
       try {
+        def drainSysmsgQueue(): Unit = {
+          // using while in case a sys msg enqueues another sys msg
+          while (sysQueue.nonEmpty) {
+            var sysQ = sysQueue.reverse
+            sysQueue = SystemMessageList.LNil
+            while (sysQ.nonEmpty) {
+              val msg = sysQ.head
+              sysQ = sysQ.tail
+              msg.unlink()
+              cell.sendSystemMessage(msg)
+            }
+          }
+        }
+
+        drainSysmsgQueue()
+
         while (!queue.isEmpty) {
           queue.poll() match {
-            case s: SystemMessage ⇒ cell.sendSystemMessage(s) // TODO: ============= CHECK SYSTEM MESSAGESSSSS =========
-            case e: Envelope with InstrumentedEnvelope ⇒
-              Tracer.withContext(e.envelopeContext().context) {
-                cell.sendMessage(e)
-              }
+            case e: Envelope with InstrumentedEnvelope => Tracer.withContext(e.envelopeContext().context) {
+              cell.sendMessage(e)
+            }
           }
+          drainSysmsgQueue()
         }
       } finally {
         unStartedCell.self.swapCell(cell)
       }
-    }
-  }
-
-  /**
-   *
-   */
-
-  @Pointcut("execution(* akka.actor.ActorCell.stop()) && this(cell)")
-  def actorStop(cell: ActorCell): Unit = {}
-
-  @After("actorStop(cell)")
-  def afterStop(cell: ActorCell): Unit = {
-    actorInstrumentation(cell).cleanup()
-
-    // The Stop can't be captured from the RoutedActorCell so we need to put this piece of cleanup here.
-    if (cell.isInstanceOf[RoutedActorCell]) {
-      cell.asInstanceOf[RouterInstrumentationAware].routerInstrumentation.cleanup()
     }
   }
 
@@ -130,21 +143,25 @@ class ActorCellInstrumentation {
 }
 
 object ActorCellInstrumentation {
-  private val (unstartedCellQueueField, unstartedCellLockField) = {
+  private val (unstartedCellQueueField, unstartedCellLockField, systemMsgQueueField) = {
     val unstartedCellClass = classOf[UnstartedCell]
-    val queueFieldName = Properties.versionNumberString.split("\\.").take(2).mkString(".") match {
-      case _@ "2.11" ⇒ "akka$actor$UnstartedCell$$queue"
-      case _@ "2.12" ⇒ "queue"
+
+    val prefix = Properties.versionNumberString.split("\\.").take(2).mkString(".") match {
+      case _@ "2.11" ⇒ "akka$actor$UnstartedCell$$"
+      case _@ "2.12" ⇒ ""
       case v         ⇒ throw new IllegalStateException(s"Incompatible Scala version: $v")
     }
 
-    val queueField = unstartedCellClass.getDeclaredField(queueFieldName)
+    val queueField = unstartedCellClass.getDeclaredField(prefix+"queue")
     queueField.setAccessible(true)
 
     val lockField = unstartedCellClass.getDeclaredField("lock")
     lockField.setAccessible(true)
 
-    (queueField, lockField)
+    val sysQueueField = unstartedCellClass.getDeclaredField(prefix+"sysmsgQueue")
+    sysQueueField.setAccessible(true)
+
+    (queueField, lockField, sysQueueField)
   }
 
 }

--- a/kamon-akka-2.4.x/src/test/scala/kamon/akka/instrumentation/ActorCellInstrumentationSpec.scala
+++ b/kamon-akka-2.4.x/src/test/scala/kamon/akka/instrumentation/ActorCellInstrumentationSpec.scala
@@ -15,20 +15,25 @@
  * ========================================================== */
 package kamon.instrumentation.akka
 
-import akka.actor.{ Actor, Props }
-import akka.pattern.{ ask, pipe }
+import akka.actor.{Actor, ActorRef, PoisonPill, Props}
+import akka.pattern.{ask, pipe}
 import akka.routing._
 import akka.util.Timeout
+import kamon.Kamon
+import kamon.akka.ActorMetrics
+import kamon.metric.{Entity, EntityRecorder}
 import kamon.testkit.BaseKamonSpec
 import kamon.trace.Tracer
+import org.scalatest.concurrent.Eventually
 
+import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
 
-class ActorCellInstrumentationSpec extends BaseKamonSpec("actor-cell-instrumentation-spec") {
+class ActorCellInstrumentationSpec extends BaseKamonSpec("actor-cell-instrumentation-spec") with Eventually {
   implicit lazy val executionContext = system.dispatcher
 
   "the message passing instrumentation" should {
-    "propagate the TraceContext using bang" in new EchoActorFixture {
+    "propagate the TraceContext usin`g bang" in new EchoActorFixture {
       val testTraceContext = Tracer.withContext(newContext("bang-reply")) {
         ctxEchoActor ! "test"
         Tracer.currentContext
@@ -86,6 +91,25 @@ class ActorCellInstrumentationSpec extends BaseKamonSpec("actor-cell-instrumenta
       }
 
       expectMsg(testTraceContext)
+    }
+
+    "be cleaned up in case of a RepointableActorRef" in {
+      def actorRecorderName(ref: ActorRef): String = system.name + "/" + ref.path.elements.mkString("/")
+
+      def actorMetricsRecorderOf(name: String): Option[EntityRecorder] =
+        Kamon.metrics.find(name, ActorMetrics.category)
+
+      val buffer = new ListBuffer[String]
+
+      for(j <- 1 to 10) {
+        for (i <- 1 to 1000) {
+          val a = system.actorOf(Props[TraceContextEcho], s"actor$j$i")
+          a ! PoisonPill
+          buffer.append(actorRecorderName(a))
+        }
+        eventually(for(p <- buffer) actorMetricsRecorderOf(p) should be(None))
+        buffer.clear()
+      }
     }
   }
 

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/ActorInstrumentation.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/ActorInstrumentation.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.locks.ReentrantLock
 
 import akka.actor._
 import akka.dispatch.Envelope
-import akka.dispatch.sysmsg.SystemMessage
+import akka.dispatch.sysmsg.{LatestFirstSystemMessageList, SystemMessage, SystemMessageList}
 import akka.routing.RoutedActorCell
 import kamon.trace.Tracer
 import org.aspectj.lang.ProceedingJoinPoint
@@ -45,6 +45,18 @@ class ActorCellInstrumentation {
     actorInstrumentation(cell).processMessage(pjp, envelope.asInstanceOf[InstrumentedEnvelope].envelopeContext())
   }
 
+  @Pointcut("execution(* akka.actor.ActorCell.terminate()) && this(cell)")
+  def callTerminate(cell: Cell) = {}
+
+  @Before("callTerminate(cell)")
+  def beforeSystemInvoke(cell: Cell): Unit = {
+    actorInstrumentation(cell).cleanup()
+
+    if (cell.isInstanceOf[RoutedActorCell]) {
+      cell.asInstanceOf[RouterInstrumentationAware].routerInstrumentation.cleanup()
+    }
+  }
+
   /**
    *
    *
@@ -80,43 +92,44 @@ class ActorCellInstrumentation {
     // TODO: Find a way to do this without resorting to reflection and, even better, without copy/pasting the Akka Code!
     val queue = unstartedCellQueueField.get(unStartedCell).asInstanceOf[java.util.LinkedList[_]]
     val lock = unstartedCellLockField.get(unStartedCell).asInstanceOf[ReentrantLock]
+    var sysQueueHead = systemMsgQueueField.get(unStartedCell).asInstanceOf[SystemMessage]
 
     def locked[T](body: ⇒ T): T = {
       lock.lock()
       try body finally lock.unlock()
     }
 
+    var sysQueue =  new LatestFirstSystemMessageList(sysQueueHead)
+
     locked {
       try {
+        def drainSysmsgQueue(): Unit = {
+          // using while in case a sys msg enqueues another sys msg
+          while (sysQueue.nonEmpty) {
+            var sysQ = sysQueue.reverse
+            sysQueue = SystemMessageList.LNil
+            while (sysQ.nonEmpty) {
+              val msg = sysQ.head
+              sysQ = sysQ.tail
+              msg.unlink()
+              cell.sendSystemMessage(msg)
+            }
+          }
+        }
+
+        drainSysmsgQueue()
+
         while (!queue.isEmpty) {
           queue.poll() match {
-            case s: SystemMessage ⇒ cell.sendSystemMessage(s) // TODO: ============= CHECK SYSTEM MESSAGESSSSS =========
-            case e: Envelope with InstrumentedEnvelope ⇒
-              Tracer.withContext(e.envelopeContext().context) {
-                cell.sendMessage(e)
-              }
+            case e: Envelope with InstrumentedEnvelope => Tracer.withContext(e.envelopeContext().context) {
+              cell.sendMessage(e)
+            }
           }
+          drainSysmsgQueue()
         }
       } finally {
         unStartedCell.self.swapCell(cell)
       }
-    }
-  }
-
-  /**
-   *
-   */
-
-  @Pointcut("execution(* akka.actor.ActorCell.stop()) && this(cell)")
-  def actorStop(cell: ActorCell): Unit = {}
-
-  @After("actorStop(cell)")
-  def afterStop(cell: ActorCell): Unit = {
-    actorInstrumentation(cell).cleanup()
-
-    // The Stop can't be captured from the RoutedActorCell so we need to put this piece of cleanup here.
-    if (cell.isInstanceOf[RoutedActorCell]) {
-      cell.asInstanceOf[RouterInstrumentationAware].routerInstrumentation.cleanup()
     }
   }
 
@@ -130,21 +143,25 @@ class ActorCellInstrumentation {
 }
 
 object ActorCellInstrumentation {
-  private val (unstartedCellQueueField, unstartedCellLockField) = {
+  private val (unstartedCellQueueField, unstartedCellLockField, systemMsgQueueField) = {
     val unstartedCellClass = classOf[UnstartedCell]
-    val queueFieldName = Properties.versionNumberString.split("\\.").take(2).mkString(".") match {
-      case _@ "2.11" ⇒ "akka$actor$UnstartedCell$$queue"
-      case _@ "2.12" ⇒ "queue"
+
+    val prefix = Properties.versionNumberString.split("\\.").take(2).mkString(".") match {
+      case _@ "2.11" ⇒ "akka$actor$UnstartedCell$$"
+      case _@ "2.12" ⇒ ""
       case v         ⇒ throw new IllegalStateException(s"Incompatible Scala version: $v")
     }
 
-    val queueField = unstartedCellClass.getDeclaredField(queueFieldName)
+    val queueField = unstartedCellClass.getDeclaredField(prefix+"queue")
     queueField.setAccessible(true)
 
     val lockField = unstartedCellClass.getDeclaredField("lock")
     lockField.setAccessible(true)
 
-    (queueField, lockField)
+    val sysQueueField = unstartedCellClass.getDeclaredField(prefix+"sysmsgQueue")
+    sysQueueField.setAccessible(true)
+
+    (queueField, lockField, sysQueueField)
   }
 
 }

--- a/kamon-akka-2.5.x/src/test/scala/kamon/akka/ActorGroupMetricsSpec.scala
+++ b/kamon-akka-2.5.x/src/test/scala/kamon/akka/ActorGroupMetricsSpec.scala
@@ -20,15 +20,15 @@ import java.nio.LongBuffer
 import akka.actor._
 import akka.routing.RoundRobinPool
 import akka.testkit.TestProbe
-import com.typesafe.config.ConfigFactory
 import kamon.Kamon
 import kamon.metric.{Entity, EntitySnapshot}
 import kamon.metric.instrument.CollectionContext
 import kamon.testkit.BaseKamonSpec
-
+import org.scalatest.concurrent.Eventually
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import scala.concurrent.duration._
 
-class ActorGroupMetricsSpec extends BaseKamonSpec("actor-group-metrics-spec") {
+class ActorGroupMetricsSpec extends BaseKamonSpec("actor-group-metrics-spec") with Eventually {
 
   "the Kamon actor-group metrics" should {
     "respect the configured include and exclude filters for actors" in new ActorGroupMetricsFixtures {
@@ -37,29 +37,31 @@ class ActorGroupMetricsSpec extends BaseKamonSpec("actor-group-metrics-spec") {
       metric.collect(collectionContext)
       val trackedActor = createTestActor("tracked-actor")
       val nonTrackedActor = createTestActor("non-tracked-actor")
+      eventually(max(metric.collect(collectionContext), "actors") shouldBe 1)
       system.stop(trackedActor)
       system.stop(nonTrackedActor)
-      max(metric.collect(collectionContext), "actors") shouldBe 1
+      eventually(max(metric.collect(collectionContext), "actors") shouldBe 0)
       val trackedActor2 = createTestActor("tracked-actor2")
       val trackedActor3 = createTestActor("tracked-actor3")
+      eventually(max(metric.collect(collectionContext), "actors") shouldBe 2)
       system.stop(trackedActor2)
       system.stop(trackedActor3)
-      max(metric.collect(collectionContext), "actors") shouldBe 2
+      eventually(max(metric.collect(collectionContext), "actors") shouldBe 0)
     }
     "respect the configured include and exclude filters for routees" in new ActorGroupMetricsFixtures {
       val metric = Kamon.metrics.entity(ActorGroupMetrics,
           Entity("tracked-group", ActorGroupMetrics.category)).asInstanceOf[ActorGroupMetrics]
-      metric.collect(collectionContext)
       val trackedRouter = createTestPoolRouter("tracked-router")
       val nonTrackedRouter = createTestPoolRouter("non-tracked-router")
+      max(metric.collect(collectionContext), "actors") shouldBe 5
       system.stop(trackedRouter)
       system.stop(nonTrackedRouter)
-      max(metric.collect(collectionContext), "actors") shouldBe 5
       val trackedActor2 = createTestPoolRouter("tracked-router2")
       val trackedActor3 = createTestPoolRouter("tracked-router3")
+      eventually(max(metric.collect(collectionContext), "actors") shouldBe 10)
       system.stop(trackedActor2)
       system.stop(trackedActor3)
-      max(metric.collect(collectionContext), "actors") shouldBe 10
+      eventually(max(metric.collect(collectionContext), "actors") shouldBe 0)
     }
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.7"
+version in ThisBuild := "0.6.8-SNAPSHOT"


### PR DESCRIPTION
Current implementation of `UnstartedCell.replaceWith` remained from akka 2.3 which changed with 2.4/2.5 to include siphoning off system messages while ref is not pointed to a proper cell causing ActorCells to hang ( as observed in #18 ).  

Now with siphoning of system messages, in busy environments if actor is created and killed immediately after doing minor work, regular actor cell receives and processes a `PoisonPill` while `UnstartedCell` is still streaming. Regular cell will invoke `stop()` on its internal ref which is still pointing to the unstarted cell which in turn will enqueue `Terminate` message for the regular cell completely bypassing the `ActorCell.stop()` and leak EntityRecorder. This is solved by cleaning actor monitor before `terminate` instead of `stop`