### PR TITLE
Message tracing and system metrics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,8 @@
 
 
 resolvers += Resolver.bintrayRepo("kamon-io", "snapshots")
-val kamonCore       = "io.kamon" %% "kamon-core"        % "1.0.0-RC2-d21434fd5bc0fcbb05f7d5b4af770225f715a93c"
-val kamonTestkit    = "io.kamon" %% "kamon-testkit"     % "1.0.0-RC2-d21434fd5bc0fcbb05f7d5b4af770225f715a93c"
+val kamonCore       = "io.kamon" %% "kamon-core"        % "1.0.0-RC3"
+val kamonTestkit    = "io.kamon" %% "kamon-testkit"     % "1.0.0-RC3"
 val kamonScala      = "io.kamon" %% "kamon-scala"       % "1.0.0-RC1-db1f817ecc74cbf623140e98d80620e0f4e01499" exclude("io.kamon", "kamon-core")
 val kamonExecutors  = "io.kamon" %% "kamon-executors"   % "1.0.0-RC1-f5ce11c766e57336d53a719377b297e64f2224a7" exclude("io.kamon", "kamon-core")
 

--- a/build.sbt
+++ b/build.sbt
@@ -15,10 +15,10 @@
 
 
 resolvers += Resolver.bintrayRepo("kamon-io", "snapshots")
-val kamonCore       = "io.kamon" %% "kamon-core"        % "1.0.0-RC2-7a21134e8e0b2296ec98061643ada2e3f68d479a"
-val kamonTestkit    = "io.kamon" %% "kamon-testkit"     % "1.0.0-RC2-7a21134e8e0b2296ec98061643ada2e3f68d479a"
-val kamonScala      = "io.kamon" %% "kamon-scala"       % "1.0.0-RC1-db1f817ecc74cbf623140e98d80620e0f4e01499"
-val kamonExecutors  = "io.kamon" %% "kamon-executors"   % "1.0.0-RC1-f5ce11c766e57336d53a719377b297e64f2224a7"
+val kamonCore       = "io.kamon" %% "kamon-core"        % "1.0.0-RC2-d21434fd5bc0fcbb05f7d5b4af770225f715a93c"
+val kamonTestkit    = "io.kamon" %% "kamon-testkit"     % "1.0.0-RC2-d21434fd5bc0fcbb05f7d5b4af770225f715a93c"
+val kamonScala      = "io.kamon" %% "kamon-scala"       % "1.0.0-RC1-db1f817ecc74cbf623140e98d80620e0f4e01499" exclude("io.kamon", "kamon-core")
+val kamonExecutors  = "io.kamon" %% "kamon-executors"   % "1.0.0-RC1-f5ce11c766e57336d53a719377b297e64f2224a7" exclude("io.kamon", "kamon-core")
 
 val `akka-2.3` = "2.3.13"
 val `akka-2.4` = "2.4.16"

--- a/build.sbt
+++ b/build.sbt
@@ -17,8 +17,8 @@
 resolvers += Resolver.bintrayRepo("kamon-io", "snapshots")
 val kamonCore       = "io.kamon" %% "kamon-core"        % "1.0.0-RC3"
 val kamonTestkit    = "io.kamon" %% "kamon-testkit"     % "1.0.0-RC3"
-val kamonScala      = "io.kamon" %% "kamon-scala"       % "1.0.0-RC1-db1f817ecc74cbf623140e98d80620e0f4e01499" exclude("io.kamon", "kamon-core")
-val kamonExecutors  = "io.kamon" %% "kamon-executors"   % "1.0.0-RC1-f5ce11c766e57336d53a719377b297e64f2224a7" exclude("io.kamon", "kamon-core")
+val kamonScala      = "io.kamon" %% "kamon-scala"       % "1.0.0-RC3-dc88b87015311d4487a3056201cd780608763137"
+val kamonExecutors  = "io.kamon" %% "kamon-executors"   % "1.0.0-RC3-bb7ce5ca4bdeff5a4f0a2b5179350e825e528ec1"
 
 val `akka-2.3` = "2.3.13"
 val `akka-2.4` = "2.4.16"

--- a/build.sbt
+++ b/build.sbt
@@ -15,10 +15,10 @@
 
 
 resolvers += Resolver.bintrayRepo("kamon-io", "snapshots")
-val kamonCore       = "io.kamon" %% "kamon-core"        % "1.0.0-RC3"
-val kamonTestkit    = "io.kamon" %% "kamon-testkit"     % "1.0.0-RC3"
-val kamonScala      = "io.kamon" %% "kamon-scala"       % "1.0.0-RC3-dc88b87015311d4487a3056201cd780608763137"
-val kamonExecutors  = "io.kamon" %% "kamon-executors"   % "1.0.0-RC3-bb7ce5ca4bdeff5a4f0a2b5179350e825e528ec1"
+val kamonCore       = "io.kamon" %% "kamon-core"        % "1.0.0-RC4"
+val kamonTestkit    = "io.kamon" %% "kamon-testkit"     % "1.0.0-RC4"
+val kamonScala      = "io.kamon" %% "kamon-scala"       % "1.0.0-RC4"
+val kamonExecutors  = "io.kamon" %% "kamon-executors"   % "1.0.0-RC4"
 
 val `akka-2.3` = "2.3.13"
 val `akka-2.4` = "2.4.18"

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ val kamonScala      = "io.kamon" %% "kamon-scala"       % "1.0.0-RC3-dc88b870153
 val kamonExecutors  = "io.kamon" %% "kamon-executors"   % "1.0.0-RC3-bb7ce5ca4bdeff5a4f0a2b5179350e825e528ec1"
 
 val `akka-2.3` = "2.3.13"
-val `akka-2.4` = "2.4.16"
+val `akka-2.4` = "2.4.18"
 val `akka-2.5` = "2.5.2"
 
 def akkaDependency(name: String, version: String) = {

--- a/build.sbt
+++ b/build.sbt
@@ -15,10 +15,10 @@
 
 
 resolvers += Resolver.bintrayRepo("kamon-io", "snapshots")
-val kamonCore  = "io.kamon" %% "kamon-core" % "1.0.0-RC1-670f32d19a30283a39a0519a74fc5c6a0efd379b" force()
-val kamonTestkit  = "io.kamon" %% "kamon-testkit" % "1.0.0-RC1-670f32d19a30283a39a0519a74fc5c6a0efd379b" force()
-val kamonScala = "io.kamon" %% "kamon-scala" % "1.0.0-RC1-a6fc82a887af5fada406d7b987f0a55ba72f1535" exclude("io.kamon", "kamon-core")
-val kamonExecutors = "io.kamon" %% "kamon-executors" % "1.0.0-RC1-d41250c58e9983f48ee3c455b3560d26846c628d" exclude("io.kamon", "kamon-core")
+val kamonCore       = "io.kamon" %% "kamon-core"        % "1.0.0-RC2-7a21134e8e0b2296ec98061643ada2e3f68d479a"
+val kamonTestkit    = "io.kamon" %% "kamon-testkit"     % "1.0.0-RC2-7a21134e8e0b2296ec98061643ada2e3f68d479a"
+val kamonScala      = "io.kamon" %% "kamon-scala"       % "1.0.0-RC1-db1f817ecc74cbf623140e98d80620e0f4e01499"
+val kamonExecutors  = "io.kamon" %% "kamon-executors"   % "1.0.0-RC1-f5ce11c766e57336d53a719377b297e64f2224a7"
 
 val `akka-2.3` = "2.3.13"
 val `akka-2.4` = "2.4.16"

--- a/kamon-akka-2.3.x/src/main/resources/META-INF/aop.xml
+++ b/kamon-akka-2.3.x/src/main/resources/META-INF/aop.xml
@@ -14,6 +14,8 @@
     <aspect name="akka.kamon.instrumentation.RoutedActorCellInstrumentation"/>
     <aspect name="akka.kamon.instrumentation.ActorLoggingInstrumentation"/>
 
+    <aspect name="akka.kamon.instrumentation.DeadLettersInstrumentation"/>
+
     <!-- Dispatchers -->
     <aspect name="akka.kamon.instrumentation.DispatcherInstrumentation"/>
     <aspect name="akka.kamon.instrumentation.DispatcherMetricCollectionInfoIntoDispatcherMixin"/>

--- a/kamon-akka-2.3.x/src/main/scala/kamon/akka/Akka.scala
+++ b/kamon-akka-2.3.x/src/main/scala/kamon/akka/Akka.scala
@@ -25,6 +25,7 @@ object Akka {
   val ActorFilterName = "akka.actor"
   val RouterFilterName = "akka.router"
   val DispatcherFilterName = "akka.dispatcher"
+  val ActorTracingFilterName = "akka-tracing"
 
   @volatile var askPatternTimeoutWarning: AskPatternTimeoutWarningSetting = Off
   @volatile var actorGroups = Seq.empty[String]

--- a/kamon-akka-2.3.x/src/main/scala/kamon/akka/Metrics.scala
+++ b/kamon-akka-2.3.x/src/main/scala/kamon/akka/Metrics.scala
@@ -38,8 +38,8 @@ object Metrics {
   val actorMailboxSizeMetric = Kamon.minMaxCounter("akka.actor.mailbox-size")
   val actorErrorsMetric = Kamon.counter("akka.actor.errors")
 
-  def forActor(path: String, system: String, dispatcher: String): ActorMetrics = {
-    val actorTags = Map("path" -> path, "system" -> system, "dispatcher" -> dispatcher)
+  def forActor(path: String, system: String, dispatcher: String, actorClass: String): ActorMetrics = {
+    val actorTags = Map("path" -> path, "system" -> system, "dispatcher" -> dispatcher, "class" -> actorClass)
     ActorMetrics(
       actorTags,
       actorTimeInMailboxMetric.refine(actorTags),
@@ -76,7 +76,7 @@ object Metrics {
   val routerProcessingTime = Kamon.histogram("akka.router.processing-time", time.nanoseconds)
   val routerErrors = Kamon.counter("akka.router.errors")
 
-  def forRouter(path: String, system: String, dispatcher: String): RouterMetrics = {
+  def forRouter(path: String, system: String, dispatcher: String, actorClass: String): RouterMetrics = {
     val routerTags = Map("path" -> path, "system" -> system, "dispatcher" -> dispatcher)
     RouterMetrics(
       routerTags,
@@ -138,6 +138,44 @@ object Metrics {
       groupMailboxSize.remove(tags)
       groupMembers.remove(tags)
       groupErrors.remove(tags)
+    }
+  }
+
+
+
+  /**
+    *
+    *  Metrics for actor systems.
+    *
+    *    - dead-letters: System global counter for messages received by dead letters.
+    *    - processed-messages: System global count of processed messages (separate for tracked and non-tracked)
+    *    - active-actors: Current count of active actors in the system.
+    */
+  val systemDeadLetters = Kamon.counter("akka.system.dead-letters")
+  val systemUnhandledMessages = Kamon.counter("akka.system.unhandled-messages")
+  val systemProcessedMessages = Kamon.counter("akka.system.processed-messages")
+  val systemActiveActors = Kamon.minMaxCounter("akka.system.active-actors")
+
+  def forSystem(name: String): ActorSystemMetrics = {
+    val systemTags = Map("system" -> name)
+    ActorSystemMetrics(
+      systemTags,
+      systemDeadLetters.refine(systemTags),
+      systemUnhandledMessages.refine(systemTags),
+      systemProcessedMessages.refine(systemTags + ("tracked" -> "true")),
+      systemProcessedMessages.refine(systemTags + ("tracked" -> "false")),
+      systemActiveActors.refine(systemTags)
+    )
+  }
+
+  case class ActorSystemMetrics(tags: Map[String, String], deadLetters: Counter, unhandledMessages: Counter, processedMessagesByTracked: Counter, processedMessagesByNonTracked: Counter, activeActors: MinMaxCounter) {
+    def cleanup(): Unit = {
+      systemDeadLetters.remove(tags)
+      systemUnhandledMessages.remove(tags)
+      systemActiveActors.remove(tags)
+      systemProcessedMessages.remove(tags + ("tracked" -> "true"))
+      systemProcessedMessages.remove(tags + ("tracked" -> "false"))
+
     }
   }
 }

--- a/kamon-akka-2.3.x/src/main/scala/kamon/akka/instrumentation/ActorInstrumentation.scala
+++ b/kamon-akka-2.3.x/src/main/scala/kamon/akka/instrumentation/ActorInstrumentation.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.locks.ReentrantLock
 
 import akka.actor._
 import akka.dispatch.Envelope
-import akka.dispatch.sysmsg.SystemMessage
+import akka.dispatch.sysmsg.{LatestFirstSystemMessageList, SystemMessage, SystemMessageList}
 import akka.routing.RoutedActorCell
 import kamon.Kamon
 import org.aspectj.lang.ProceedingJoinPoint
@@ -42,7 +42,7 @@ class ActorCellInstrumentation {
 
   @Around("invokingActorBehaviourAtActorCell(cell, envelope)")
   def aroundBehaviourInvoke(pjp: ProceedingJoinPoint, cell: ActorCell, envelope: Envelope): Any = {
-    actorInstrumentation(cell).processMessage(pjp, envelope.asInstanceOf[InstrumentedEnvelope].timestampedContext())
+    actorInstrumentation(cell).processMessage(pjp, envelope.asInstanceOf[InstrumentedEnvelope].timestampedContext(), envelope)
   }
 
   @Pointcut("execution(* akka.actor.ActorCell.terminate()) && this(cell)")
@@ -56,7 +56,6 @@ class ActorCellInstrumentation {
       cell.asInstanceOf[RouterInstrumentationAware].routerInstrumentation.cleanup()
     }
   }
-
 
   /**
    *

--- a/kamon-akka-2.3.x/src/main/scala/kamon/akka/instrumentation/ActorMonitor.scala
+++ b/kamon-akka-2.3.x/src/main/scala/kamon/akka/instrumentation/ActorMonitor.scala
@@ -1,46 +1,54 @@
 package akka.kamon.instrumentation
 
 import akka.actor.{ActorRef, ActorSystem, Cell}
-import akka.kamon.instrumentation.ActorMonitors.{TrackedActor, TrackedRoutee}
+import akka.dispatch.Envelope
+import akka.kamon.instrumentation.ActorMonitors.{TracedMonitor, TrackedActor, TrackedRoutee}
 import kamon.Kamon
 import kamon.akka.Metrics
 import kamon.akka.Metrics.{ActorGroupMetrics, ActorMetrics, RouterMetrics}
+import kamon.context.Context
+import kamon.trace.Span
 import org.aspectj.lang.ProceedingJoinPoint
 
 trait ActorMonitor {
   def captureEnvelopeContext(): TimestampedContext
-  def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext): AnyRef
+  def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext, envelope: Envelope): AnyRef
   def processFailure(failure: Throwable): Unit
   def cleanup(): Unit
 }
+
 
 object ActorMonitor {
 
   def createActorMonitor(cell: Cell, system: ActorSystem, ref: ActorRef, parent: ActorRef, actorCellCreation: Boolean): ActorMonitor = {
     val cellInfo = CellInfo.cellInfoFor(cell, system, ref, parent, actorCellCreation)
 
-    if (cellInfo.isRouter)
-      ActorMonitors.ContextPropagationOnly
+    Metrics.forSystem(system.name).activeActors.increment()
+
+    val monitor = if (cellInfo.isRouter)
+      ActorMonitors.ContextPropagationOnly(cellInfo)
     else {
       if (cellInfo.isRoutee && cellInfo.isTracked)
         createRouteeMonitor(cellInfo)
       else
         createRegularActorMonitor(cellInfo)
     }
+
+    if(cellInfo.isTraced) new TracedMonitor(cellInfo, monitor) else monitor
   }
 
   def createRegularActorMonitor(cellInfo: CellInfo): ActorMonitor = {
     if (cellInfo.isTracked || !cellInfo.trackingGroups.isEmpty) {
-      val actorMetrics = if (cellInfo.isTracked) Some(Metrics.forActor(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName)) else None
-      new TrackedActor(actorMetrics, trackingGroupMetrics(cellInfo), cellInfo.actorCellCreation)
+      val actorMetrics = if (cellInfo.isTracked) Some(Metrics.forActor(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName, cellInfo.actorClass)) else None
+      new TrackedActor(actorMetrics, trackingGroupMetrics(cellInfo), cellInfo.actorCellCreation, cellInfo)
     } else {
-      ActorMonitors.ContextPropagationOnly
+      ActorMonitors.ContextPropagationOnly(cellInfo)
     }
   }
 
   def createRouteeMonitor(cellInfo: CellInfo): ActorMonitor = {
-    val routerMetrics = Metrics.forRouter(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName)
-    new TrackedRoutee(routerMetrics, trackingGroupMetrics(cellInfo), cellInfo.actorCellCreation)
+    val routerMetrics = Metrics.forRouter(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName, cellInfo.actorClass)
+    new TrackedRoutee(routerMetrics, trackingGroupMetrics(cellInfo), cellInfo.actorCellCreation, cellInfo)
   }
 
   private def trackingGroupMetrics(cellInfo: CellInfo): Seq[ActorGroupMetrics] = {
@@ -52,23 +60,76 @@ object ActorMonitor {
 
 object ActorMonitors {
 
-  val ContextPropagationOnly = new ActorMonitor {
-    def captureEnvelopeContext(): TimestampedContext =
-      TimestampedContext(0, Kamon.currentContext())
+  class TracedMonitor(cellInfo: CellInfo, monitor: ActorMonitor) extends ActorMonitor {
 
-    def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext): AnyRef = {
+    override def captureEnvelopeContext(): TimestampedContext = {
+      val currCtx = Kamon.currentContext()
+      val currSpan = currCtx.get(Span.ContextKey)
+      val newSpan = Kamon.buildSpan(cellInfo.actorName)
+        .asChildOf(currSpan)
+        .start()
+        .mark("enqueued")
+
+      monitor.captureEnvelopeContext().copy(
+        context = currCtx.withKey(Span.ContextKey, newSpan)
+      )
+    }
+
+    override def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext, envelope: Envelope): AnyRef = {
+      tagSpan(cellInfo, envelope, envelopeContext.context)
+      val res = monitor.processMessage(pjp, envelopeContext, envelope)
+      finishSpan(envelopeContext.context)
+      res
+    }
+
+    override def processFailure(failure: Throwable): Unit = monitor.processFailure(failure)
+
+    override def cleanup(): Unit = monitor.cleanup()
+
+    private def tagSpan(cellInfo: CellInfo, envelope: Envelope, context: Context) = {
+      val span = context.get(Span.ContextKey)
+      val messageClass = envelope.message.getClass.getSimpleName
+
+      span.setOperationName(s"${cellInfo.actorName}.$messageClass")
+
+      span.mark("dequeued")
+
+      span.tag("path", cellInfo.path)
+      span.tag("system", cellInfo.systemName)
+      span.tag("actor-class", cellInfo.actorClass)
+      span.tag("message-class", messageClass)
+    }
+
+    private def finishSpan(context: Context) = {
+      val span = context.get(Span.ContextKey)
+      span.mark("processed")
+      span.finish()
+    }
+
+  }
+
+
+  def ContextPropagationOnly(cellInfo: CellInfo) = new ActorMonitor {
+    def captureEnvelopeContext(): TimestampedContext = TimestampedContext(0, Kamon.currentContext())//tracedContext(cellInfo.isTracked, cellInfo.traced, Kamon.currentContext())
+
+    def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext, envelope: Envelope): AnyRef = {
+      Metrics.forSystem(cellInfo.systemName).processedMessagesByNonTracked.increment()
+
       Kamon.withContext(envelopeContext.context) {
         pjp.proceed()
       }
     }
 
     def processFailure(failure: Throwable): Unit = {}
-    def cleanup(): Unit = {}
-
+    def cleanup(): Unit = {
+      Metrics.forSystem(cellInfo.systemName).activeActors.decrement()
+    }
   }
 
-  class TrackedActor(actorMetrics: Option[ActorMetrics], groupMetrics: Seq[ActorGroupMetrics], actorCellCreation: Boolean)
-      extends GroupMetricsTrackingActor(groupMetrics, actorCellCreation) {
+
+
+  class TrackedActor(actorMetrics: Option[ActorMetrics], groupMetrics: Seq[ActorGroupMetrics], actorCellCreation: Boolean, cellInfo: CellInfo)
+      extends GroupMetricsTrackingActor(groupMetrics, actorCellCreation, cellInfo) {
 
     override def captureEnvelopeContext(): TimestampedContext = {
       actorMetrics.foreach { am =>
@@ -77,14 +138,14 @@ object ActorMonitors {
       super.captureEnvelopeContext()
     }
 
-    def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext): AnyRef = {
+    def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext, envelope: Envelope): AnyRef = {
       val timestampBeforeProcessing = System.nanoTime()
+      Metrics.forSystem(cellInfo.systemName).processedMessagesByTracked.increment()
 
       try {
         Kamon.withContext(envelopeContext.context) {
           pjp.proceed()
         }
-
       } finally {
         val timestampAfterProcessing = System.nanoTime()
         val timeInMailbox = timestampBeforeProcessing - envelopeContext.nanoTime
@@ -112,17 +173,17 @@ object ActorMonitors {
     }
   }
 
-  class TrackedRoutee(routerMetrics: RouterMetrics, groupMetrics: Seq[ActorGroupMetrics], actorCellCreation: Boolean)
-      extends GroupMetricsTrackingActor(groupMetrics, actorCellCreation) {
+  class TrackedRoutee(routerMetrics: RouterMetrics, groupMetrics: Seq[ActorGroupMetrics], actorCellCreation: Boolean, cellInfo: CellInfo)
+      extends GroupMetricsTrackingActor(groupMetrics, actorCellCreation, cellInfo) {
 
-    def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext): AnyRef = {
+    def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext, envelope: Envelope): AnyRef = {
       val timestampBeforeProcessing = System.nanoTime()
+      Metrics.forSystem(cellInfo.systemName).processedMessagesByTracked.increment()
 
       try {
         Kamon.withContext(envelopeContext.context) {
           pjp.proceed()
         }
-
       } finally {
         val timestampAfterProcessing = System.nanoTime()
         val timeInMailbox = timestampBeforeProcessing - envelopeContext.nanoTime
@@ -145,7 +206,7 @@ object ActorMonitors {
     }
   }
 
-  abstract class GroupMetricsTrackingActor(groupMetrics: Seq[ActorGroupMetrics], actorCellCreation: Boolean) extends ActorMonitor {
+  abstract class GroupMetricsTrackingActor(groupMetrics: Seq[ActorGroupMetrics], actorCellCreation: Boolean, cellInfo: CellInfo) extends ActorMonitor {
     if (actorCellCreation) {
       groupMetrics.foreach { gm =>
         gm.members.increment()
@@ -175,6 +236,7 @@ object ActorMonitors {
     }
 
     def cleanup(): Unit = {
+      Metrics.forSystem(cellInfo.systemName).activeActors.decrement()
       if (actorCellCreation) {
         groupMetrics.foreach { gm =>
           gm.members.decrement()

--- a/kamon-akka-2.3.x/src/main/scala/kamon/akka/instrumentation/DeadLettersInstrumentation.scala
+++ b/kamon-akka-2.3.x/src/main/scala/kamon/akka/instrumentation/DeadLettersInstrumentation.scala
@@ -1,0 +1,54 @@
+package akka.kamon.instrumentation
+
+import akka.actor.{ActorSystem, DeadLetter, UnhandledMessage}
+import akka.event.EventStream
+import kamon.akka.Metrics
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation._
+
+trait HasSystem {
+  def system: ActorSystem
+  def setSystem(system: ActorSystem): Unit
+}
+
+object HasSystem {
+  def apply(): HasSystem = new HasSystem {
+    private var _system: ActorSystem = _
+
+    override def system: ActorSystem = _system
+
+    override def setSystem(system: ActorSystem): Unit = _system = system
+  }
+}
+
+@Aspect
+class DeadLettersInstrumentation {
+
+  @DeclareMixin("akka.event.EventStream+")
+  def mixinHasSystem: HasSystem = HasSystem()
+
+  @Pointcut("call(akka.event.EventStream.new(..)) && this(system) && args(debug)")
+  def eventStreamCreation(system: ActorSystem, debug: Boolean): Unit = {}
+
+  @Around("eventStreamCreation(system, debug)")
+  def aroundEventStreamCreateion(pjp: ProceedingJoinPoint, system: ActorSystem, debug: Boolean): EventStream = {
+    val stream = pjp.proceed().asInstanceOf[EventStream]
+    stream.asInstanceOf[HasSystem].setSystem(system)
+    stream
+  }
+
+
+  @Pointcut("execution(* akka.event.EventStream.publish(..)) && this(stream) && args(event)")
+  def streamPublish(stream: HasSystem, event: AnyRef): Unit = {}
+
+  @After("streamPublish(stream, event)")
+  def afterStreamSubchannel(stream: HasSystem, event: AnyRef): Unit = trackEvent(stream, event)
+
+
+  private def trackEvent(stream: HasSystem, event: AnyRef): Unit = event match {
+    case dl: DeadLetter => Metrics.forSystem(stream.system.name).deadLetters.increment()
+    case um: UnhandledMessage => Metrics.forSystem(stream.system.name).unhandledMessages.increment()
+    case _ => ()
+  }
+
+}

--- a/kamon-akka-2.3.x/src/main/scala/kamon/akka/instrumentation/DispatcherInstrumentation.scala
+++ b/kamon-akka-2.3.x/src/main/scala/kamon/akka/instrumentation/DispatcherInstrumentation.scala
@@ -37,6 +37,14 @@ import scala.collection.concurrent.TrieMap
 class DispatcherInstrumentation {
   import DispatcherInstrumentation.registeredDispatchers
 
+  @Pointcut("execution(* akka.dispatch.ForkJoinExecutorConfigurator.ForkJoinExecutorServiceFactory.createExecutorService())")
+  def executorConstruction(): Unit = {}
+
+  @Around("executorConstruction()")
+  def aroundexecutorConstruction(pjp: ProceedingJoinPoint): ExecutorService = Executors.instrument(
+    pjp.proceed().asInstanceOf[ExecutorService]
+  )
+
   @Pointcut("execution(* akka.actor.ActorSystemImpl.start(..)) && this(system)")
   def actorSystemInitialization(system: ActorSystemImpl): Unit = {}
 

--- a/kamon-akka-2.3.x/src/main/scala/kamon/akka/instrumentation/RouterMonitor.scala
+++ b/kamon-akka-2.3.x/src/main/scala/kamon/akka/instrumentation/RouterMonitor.scala
@@ -20,7 +20,7 @@ object RouterMonitor {
     val cellInfo = CellInfo.cellInfoFor(cell, cell.system, cell.self, cell.parent, false)
 
     if (cellInfo.isTracked)
-      new MetricsOnlyRouterMonitor(Metrics.forRouter(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName))
+      new MetricsOnlyRouterMonitor(Metrics.forRouter(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName, cellInfo.actorClass))
     else NoOpRouterMonitor
   }
 }

--- a/kamon-akka-2.3.x/src/test/resources/application.conf
+++ b/kamon-akka-2.3.x/src/test/resources/application.conf
@@ -48,9 +48,16 @@ kamon {
         includes = ["*/user/group-of-routees*"]
         excludes = []
       }
+
+      akka-tracing {
+        includes = [ "*/user/traced*" ]
+        excludes = []
+      }
     }
 
   }
+
+  trace.sampler = "always"
 
   default-instrument-settings {
     gauge.refresh-interval = 1 hour

--- a/kamon-akka-2.3.x/src/test/resources/application.conf
+++ b/kamon-akka-2.3.x/src/test/resources/application.conf
@@ -67,6 +67,9 @@ explicitly-excluded {
   executor = "fork-join-executor"
 }
 
+
+akka.actor.default-dispatcher.shutdown-timeout = 30s
+
 tracked-fjp {
   type = "Dispatcher"
   executor = "fork-join-executor"

--- a/kamon-akka-2.3.x/src/test/scala/kamon/akka/ActorMetricsSpec.scala
+++ b/kamon-akka-2.3.x/src/test/scala/kamon/akka/ActorMetricsSpec.scala
@@ -114,13 +114,62 @@ class ActorMetricsSpec extends TestKit(ActorSystem("ActorMetricsSpec")) with Wor
     }
   }
 
+  "the Kamon system metrics" should {
+    val systemMetrics= Metrics.forSystem(system.name)
+    "record deadletters" in {
+      val doaActor = system.actorOf(Props[ActorMetricsTestActor], "doa")
+
+      val deathWatcher = TestProbe()
+      deathWatcher.watch(doaActor)
+      doaActor ! PoisonPill
+      deathWatcher.expectTerminated(doaActor)
+
+      (1 to 7).foreach(_ =>  doaActor ! "deadonarrival")
+      eventually {
+        systemMetrics.deadLetters.value(false).toInt should be(7)
+      }
+    }
+
+    "record unhandeled messages" in {
+      val hndl = system.actorOf(Props[ActorMetricsTestActor], "nonhandled")
+
+      (1 to 10).foreach(_ => hndl ! "CantHandleStrings")
+      eventually {
+        systemMetrics.unhandledMessages.value(false).toInt should be(10)
+      }
+    }
+
+    "record active actor counts" in {
+      systemMetrics.activeActors.distribution(true)
+      (1 to 8).foreach(i => system.actorOf(Props[ActorMetricsTestActor], s"counted-$i"))
+      eventually {
+        systemMetrics.activeActors.distribution(false).max.toInt should be > 0
+      }
+    }
+
+    "record processed messages counts" in {
+      systemMetrics.processedMessagesByTracked.value(true)
+      systemMetrics.processedMessagesByNonTracked.value(true)
+
+      val tracked = system.actorOf(Props[ActorMetricsTestActor], "tracked-actor-counts")
+      val nonTracked = system.actorOf(Props[ActorMetricsTestActor], "non-tracked-actor-counts")
+
+      (1 to 10).foreach(_ => tracked ! Discard)
+      (1 to 15).foreach(_ => nonTracked ! Discard)
+
+      eventually(systemMetrics.processedMessagesByTracked.value(false) should be(10))
+      eventually(systemMetrics.processedMessagesByNonTracked.value(false) should be(15))
+    }
+  }
+
   override protected def afterAll(): Unit = shutdown()
 
   def actorTags(path: String): Map[String, String] =
     Map(
       "path" -> path,
       "system" -> "ActorMetricsSpec",
-      "dispatcher" -> "akka.actor.default-dispatcher"
+      "dispatcher" -> "akka.actor.default-dispatcher",
+      "class" -> "kamon.akka.ActorMetricsTestActor"
     )
 
   trait ActorMetricsFixtures {

--- a/kamon-akka-2.3.x/src/test/scala/kamon/akka/DispatcherMetricsSpec.scala
+++ b/kamon-akka-2.3.x/src/test/scala/kamon/akka/DispatcherMetricsSpec.scala
@@ -29,32 +29,31 @@ import org.scalatest.concurrent.Eventually
 import scala.concurrent.Future
 
 class DispatcherMetricsSpec extends TestKit(ActorSystem("DispatcherMetricsSpec")) with WordSpecLike with MetricInspection with Matchers
-    with BeforeAndAfterAll with ImplicitSender with Eventually {
+  with BeforeAndAfterAll with ImplicitSender with Eventually {
 
   "the Kamon dispatcher metrics" should {
-    "track dispatchers configured in the akka.dispatcher filter" in {
-      forceInit(system.dispatchers.lookup("akka.actor.default-dispatcher"))
-      forceInit(system.dispatchers.lookup("tracked-fjp"))
-      forceInit(system.dispatchers.lookup("tracked-tpe"))
-      forceInit(system.dispatchers.lookup("explicitly-excluded"))
 
-      forkJoinPoolParallelism.valuesForTag("name") should contain only("akka.actor.default-dispatcher", "tracked-fjp")
-      threadPoolSize.valuesForTag("name") should contain only("tracked-tpe")
+    val dispatcherMetrics = Seq(Pool, Threads, Tasks, Queue)
+
+    val trackedDispatchers = Seq(
+      "akka.actor.default-dispatcher",
+      "tracked-fjp",
+      "tracked-tpe"
+    )
+    val allDispatchers = trackedDispatchers :+ "explicitly-excluded"
+
+    "track dispatchers configured in the akka.dispatcher filter" in {
+      allDispatchers.foreach(id => forceInit(system.dispatchers.lookup(id)))
+
+      val dispatcherMetricTags = dispatcherMetrics.map(_.partialRefineKeys(Set("name"))).flatten
+
+      trackedDispatchers.forall(d => dispatcherMetricTags.exists(_.get("name").get == d)) should be (true)
     }
 
-
     "clean up the metrics recorders after a dispatcher is shutdown" in {
-      implicit val tpeDispatcher = system.dispatchers.lookup("tracked-tpe")
-      implicit val fjpDispatcher = system.dispatchers.lookup("tracked-fjp")
-
-      forkJoinPoolParallelism.valuesForTag("name") should contain("tracked-fjp")
-      threadPoolSize.valuesForTag("name") should contain("tracked-tpe")
-
-      shutdownDispatcher(tpeDispatcher)
-      shutdownDispatcher(fjpDispatcher)
-
-      forkJoinPoolParallelism.valuesForTag("name") shouldNot contain("tracked-fjp")
-      threadPoolSize.valuesForTag("name") shouldNot contain("tracked-tpe")
+      Pool.valuesForTag("name") should contain("tracked-fjp")
+      shutdownDispatcher(system.dispatchers.lookup("tracked-fjp"))
+      Pool.valuesForTag("name") shouldNot contain("tracked-fjp")
     }
 
     "play nicely when dispatchers are looked up from a BalancingPool router" in {
@@ -62,8 +61,9 @@ class DispatcherMetricsSpec extends TestKit(ActorSystem("DispatcherMetricsSpec")
       balancingPoolRouter ! Ping
       expectMsg(Pong)
 
-      forkJoinPoolParallelism.valuesForTag("name") should contain("BalancingPool-/test-balancing-pool")
+      Pool.valuesForTag("name") should contain("BalancingPool-/test-balancing-pool")
     }
+
   }
 
 
@@ -76,10 +76,6 @@ class DispatcherMetricsSpec extends TestKit(ActorSystem("DispatcherMetricsSpec")
 
     dispatcher
   }
-
-  def submit(dispatcher: MessageDispatcher): Future[String] = Future {
-    "hello"
-  }(dispatcher)
 
   def shutdownDispatcher(dispatcher: MessageDispatcher): Unit = {
     val shutdownMethod = dispatcher.getClass.getDeclaredMethod("shutdown")

--- a/kamon-akka-2.3.x/src/test/scala/kamon/akka/instrumentation/MessageTracingSpec.scala
+++ b/kamon-akka-2.3.x/src/test/scala/kamon/akka/instrumentation/MessageTracingSpec.scala
@@ -1,0 +1,110 @@
+package kamon.akka.instrumentation
+
+import akka.actor.{Actor, ActorRef, ActorSystem, Props}
+import akka.routing.RoundRobinGroup
+import akka.testkit.{ImplicitSender, TestKit}
+import kamon.Kamon
+import kamon.testkit.{MetricInspection, SpanInspection}
+import kamon.trace.Span
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+
+
+class RootActor(tester: Option[ActorRef]) extends Actor with SpanInspection {
+
+  def currentSpan = Kamon.currentContext().get(Span.ContextKey)
+
+  override def receive: Receive = {
+    case (forwardTo: ActorRef, target: ActorRef) => {
+      tester.foreach(_ ! currentSpan)
+      forwardTo ! target
+    }
+    case forwardTo: ActorRef => {
+      tester.foreach(_ ! currentSpan)
+      forwardTo ! "span"
+    }
+    case "span" => {
+      tester.foreach(_ ! currentSpan)
+    }
+
+  }
+}
+
+class MessageTracingSpec extends TestKit(ActorSystem("MessageTracing")) with WordSpecLike with MetricInspection with Matchers with SpanInspection
+  with BeforeAndAfterAll with ImplicitSender with Eventually {
+
+  "Message tracing instrumentation" should {
+
+    "skip filtered out actors" in {
+      val traced = system.actorOf(Props(classOf[RootActor], Some(testActor)), "filteredout")
+      traced ! "span"
+      assert(expectMsgType[Span] == Span.Empty)
+    }
+
+    "construct span for traced actors" in {
+      val traced = system.actorOf(Props(classOf[RootActor], Some(testActor)), "traced")
+      traced ! "span"
+      val spanCtx = inspect(expectMsgType[Span]).context()
+      assert(spanCtx.parentID.string.isEmpty)
+      assert(spanCtx.spanID.string.nonEmpty)
+      assert(spanCtx.traceID.string.nonEmpty)
+    }
+
+    "create child spans for messages between traced actors" in {
+      val root = system.actorOf(Props(classOf[RootActor], Some(testActor)), "traced-root")
+      val child = system.actorOf(Props(classOf[RootActor], Some(testActor)), "traced-child")
+
+      root ! child
+
+      val rootSpan = inspect(expectMsgType[Span]).context()
+      val childSpan = inspect(expectMsgType[Span]).context()
+
+      assert(rootSpan.parentID.string.isEmpty)
+      assert(childSpan.parentID.string == rootSpan.spanID.string)
+    }
+
+    "create hierarchy of spans even across propagation-only actors" in {
+      val root = system.actorOf(Props(classOf[RootActor], Some(testActor)), "traced-chain-root")
+      val noninstrumented = system.actorOf(Props(classOf[RootActor], Some(testActor)), "filteredout-child")
+      val child = system.actorOf(Props(classOf[RootActor], Some(testActor)), "traced-chain-child")
+
+      root ! (noninstrumented, child)
+
+      val rootSpan = inspect(expectMsgType[Span]).context()
+      val nonInstrumented = inspect(expectMsgType[Span]).context()
+      val childSpan = inspect(expectMsgType[Span]).context()
+
+      assert(rootSpan.parentID.string.isEmpty)
+      assert(nonInstrumented.spanID.string == rootSpan.spanID.string)
+      assert(childSpan.parentID.string == rootSpan.spanID.string)
+    }
+
+    "create routee spans as child of original when router is not traced" in {
+      val root = system.actorOf(Props(classOf[RootActor], Some(testActor)),"traced-router-root")
+      val routee = system.actorOf(Props(classOf[RootActor], Some(testActor)),"traced-routee-one")
+      val router = system.actorOf(RoundRobinGroup(Vector(routee.path.toStringWithoutAddress)).props(), "nontraced-pool-router")
+
+      root ! router
+
+      val rootSpan = inspect(expectMsgType[Span]).context()
+      val routeeOne = inspect(expectMsgType[Span]).context()
+
+      assert(rootSpan.spanID.string == routeeOne.parentID.string)
+    }
+
+    "create parent-child spans for router-routee when both are traced" in {
+      val routee = system.actorOf(Props(classOf[RootActor], Some(testActor)),"traced-routee")
+      val router = system.actorOf(RoundRobinGroup(Vector(routee.path.toStringWithoutAddress)).props(), "traced-pool-router")
+
+      router ! "span"
+
+      val routeeSpan = inspect(expectMsgType[Span]).context()
+
+      assert(routeeSpan.parentID.string.nonEmpty)
+    }
+
+  }
+
+
+
+}

--- a/kamon-akka-2.4.x/src/main/resources/META-INF/aop.xml
+++ b/kamon-akka-2.4.x/src/main/resources/META-INF/aop.xml
@@ -14,6 +14,8 @@
     <aspect name="akka.kamon.instrumentation.RoutedActorCellInstrumentation"/>
     <aspect name="akka.kamon.instrumentation.ActorLoggingInstrumentation"/>
 
+    <aspect name="akka.kamon.instrumentation.DeadLettersInstrumentation"/>
+
     <!-- Dispatchers -->
     <aspect name="akka.kamon.instrumentation.DispatcherInstrumentation"/>
     <aspect name="akka.kamon.instrumentation.DispatcherMetricCollectionInfoIntoDispatcherMixin"/>

--- a/kamon-akka-2.4.x/src/main/resources/reference.conf
+++ b/kamon-akka-2.4.x/src/main/resources/reference.conf
@@ -51,6 +51,11 @@ kamon {
       includes = []
       excludes = []
     }
+
+    akka-tracing {
+      includes = []
+      excludes = []
+    }
   }
 
   modules {

--- a/kamon-akka-2.4.x/src/main/scala/kamon/akka/Akka.scala
+++ b/kamon-akka-2.4.x/src/main/scala/kamon/akka/Akka.scala
@@ -25,6 +25,7 @@ object Akka {
   val ActorFilterName = "akka.actor"
   val RouterFilterName = "akka.router"
   val DispatcherFilterName = "akka.dispatcher"
+  val ActorTracingFilterName = "akka-tracing"
 
   @volatile var askPatternTimeoutWarning: AskPatternTimeoutWarningSetting = Off
   @volatile var actorGroups = Seq.empty[String]

--- a/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/ActorInstrumentation.scala
+++ b/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/ActorInstrumentation.scala
@@ -42,7 +42,7 @@ class ActorCellInstrumentation {
 
   @Around("invokingActorBehaviourAtActorCell(cell, envelope)")
   def aroundBehaviourInvoke(pjp: ProceedingJoinPoint, cell: ActorCell, envelope: Envelope): Any = {
-    actorInstrumentation(cell).processMessage(pjp, envelope.asInstanceOf[InstrumentedEnvelope].timestampedContext())
+    actorInstrumentation(cell).processMessage(pjp, envelope.asInstanceOf[InstrumentedEnvelope].timestampedContext(), envelope)
   }
 
   @Pointcut("execution(* akka.actor.ActorCell.terminate()) && this(cell)")

--- a/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/ActorMonitor.scala
+++ b/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/ActorMonitor.scala
@@ -1,46 +1,54 @@
 package akka.kamon.instrumentation
 
 import akka.actor.{ActorRef, ActorSystem, Cell}
-import akka.kamon.instrumentation.ActorMonitors.{TrackedActor, TrackedRoutee}
+import akka.dispatch.Envelope
+import akka.kamon.instrumentation.ActorMonitors.{TracedMonitor, TrackedActor, TrackedRoutee}
 import kamon.Kamon
 import kamon.akka.Metrics
 import kamon.akka.Metrics.{ActorGroupMetrics, ActorMetrics, RouterMetrics}
+import kamon.context.Context
+import kamon.trace.Span
 import org.aspectj.lang.ProceedingJoinPoint
 
 trait ActorMonitor {
   def captureEnvelopeContext(): TimestampedContext
-  def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext): AnyRef
+  def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext, envelope: Envelope): AnyRef
   def processFailure(failure: Throwable): Unit
   def cleanup(): Unit
 }
+
 
 object ActorMonitor {
 
   def createActorMonitor(cell: Cell, system: ActorSystem, ref: ActorRef, parent: ActorRef, actorCellCreation: Boolean): ActorMonitor = {
     val cellInfo = CellInfo.cellInfoFor(cell, system, ref, parent, actorCellCreation)
 
-    if (cellInfo.isRouter)
-      ActorMonitors.ContextPropagationOnly
+    Metrics.forSystem(system.name).activeActors.increment()
+
+    val monitor = if (cellInfo.isRouter)
+      ActorMonitors.ContextPropagationOnly(cellInfo)
     else {
       if (cellInfo.isRoutee && cellInfo.isTracked)
         createRouteeMonitor(cellInfo)
       else
         createRegularActorMonitor(cellInfo)
     }
+
+    if(cellInfo.isTraced) new TracedMonitor(cellInfo, monitor) else monitor
   }
 
   def createRegularActorMonitor(cellInfo: CellInfo): ActorMonitor = {
     if (cellInfo.isTracked || !cellInfo.trackingGroups.isEmpty) {
-      val actorMetrics = if (cellInfo.isTracked) Some(Metrics.forActor(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName)) else None
-      new TrackedActor(actorMetrics, trackingGroupMetrics(cellInfo), cellInfo.actorCellCreation)
+      val actorMetrics = if (cellInfo.isTracked) Some(Metrics.forActor(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName, cellInfo.actorClass)) else None
+      new TrackedActor(actorMetrics, trackingGroupMetrics(cellInfo), cellInfo.actorCellCreation, cellInfo)
     } else {
-      ActorMonitors.ContextPropagationOnly
+      ActorMonitors.ContextPropagationOnly(cellInfo)
     }
   }
 
   def createRouteeMonitor(cellInfo: CellInfo): ActorMonitor = {
-    val routerMetrics = Metrics.forRouter(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName)
-    new TrackedRoutee(routerMetrics, trackingGroupMetrics(cellInfo), cellInfo.actorCellCreation)
+    val routerMetrics = Metrics.forRouter(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName, cellInfo.actorClass)
+    new TrackedRoutee(routerMetrics, trackingGroupMetrics(cellInfo), cellInfo.actorCellCreation, cellInfo)
   }
 
   private def trackingGroupMetrics(cellInfo: CellInfo): Seq[ActorGroupMetrics] = {
@@ -52,23 +60,76 @@ object ActorMonitor {
 
 object ActorMonitors {
 
-  val ContextPropagationOnly = new ActorMonitor {
-    def captureEnvelopeContext(): TimestampedContext =
-      TimestampedContext(0, Kamon.currentContext())
+  class TracedMonitor(cellInfo: CellInfo, monitor: ActorMonitor) extends ActorMonitor {
 
-    def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext): AnyRef = {
+    override def captureEnvelopeContext(): TimestampedContext = {
+      val currCtx = Kamon.currentContext()
+      val currSpan = currCtx.get(Span.ContextKey)
+      val newSpan = Kamon.buildSpan(cellInfo.actorName)
+        .asChildOf(currSpan)
+        .start()
+        .mark("enqueued")
+
+      monitor.captureEnvelopeContext().copy(
+        context = currCtx.withKey(Span.ContextKey, newSpan)
+      )
+    }
+
+    override def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext, envelope: Envelope): AnyRef = {
+      tagSpan(cellInfo, envelope, envelopeContext.context)
+      val res = monitor.processMessage(pjp, envelopeContext, envelope)
+      finishSpan(envelopeContext.context)
+      res
+    }
+
+    override def processFailure(failure: Throwable): Unit = monitor.processFailure(failure)
+
+    override def cleanup(): Unit = monitor.cleanup()
+
+    private def tagSpan(cellInfo: CellInfo, envelope: Envelope, context: Context) = {
+      val span = context.get(Span.ContextKey)
+      val messageClass = envelope.message.getClass.getSimpleName
+
+      span.setOperationName(s"${cellInfo.actorName}.$messageClass")
+
+      span.mark("dequeued")
+
+      span.tag("path", cellInfo.path)
+      span.tag("system", cellInfo.systemName)
+      span.tag("actor-class", cellInfo.actorClass)
+      span.tag("message-class", messageClass)
+    }
+
+    private def finishSpan(context: Context) = {
+      val span = context.get(Span.ContextKey)
+      span.mark("processed")
+      span.finish()
+    }
+
+  }
+
+
+  def ContextPropagationOnly(cellInfo: CellInfo) = new ActorMonitor {
+    def captureEnvelopeContext(): TimestampedContext = TimestampedContext(0, Kamon.currentContext())//tracedContext(cellInfo.isTracked, cellInfo.traced, Kamon.currentContext())
+
+    def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext, envelope: Envelope): AnyRef = {
+      Metrics.forSystem(cellInfo.systemName).processedMessagesByNonTracked.increment()
+
       Kamon.withContext(envelopeContext.context) {
         pjp.proceed()
       }
     }
 
     def processFailure(failure: Throwable): Unit = {}
-    def cleanup(): Unit = {}
-
+    def cleanup(): Unit = {
+      Metrics.forSystem(cellInfo.systemName).activeActors.decrement()
+    }
   }
 
-  class TrackedActor(actorMetrics: Option[ActorMetrics], groupMetrics: Seq[ActorGroupMetrics], actorCellCreation: Boolean)
-      extends GroupMetricsTrackingActor(groupMetrics, actorCellCreation) {
+
+
+  class TrackedActor(actorMetrics: Option[ActorMetrics], groupMetrics: Seq[ActorGroupMetrics], actorCellCreation: Boolean, cellInfo: CellInfo)
+      extends GroupMetricsTrackingActor(groupMetrics, actorCellCreation, cellInfo) {
 
     override def captureEnvelopeContext(): TimestampedContext = {
       actorMetrics.foreach { am =>
@@ -77,14 +138,14 @@ object ActorMonitors {
       super.captureEnvelopeContext()
     }
 
-    def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext): AnyRef = {
+    def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext, envelope: Envelope): AnyRef = {
       val timestampBeforeProcessing = System.nanoTime()
+      Metrics.forSystem(cellInfo.systemName).processedMessagesByTracked.increment()
 
       try {
         Kamon.withContext(envelopeContext.context) {
           pjp.proceed()
         }
-
       } finally {
         val timestampAfterProcessing = System.nanoTime()
         val timeInMailbox = timestampBeforeProcessing - envelopeContext.nanoTime
@@ -112,17 +173,17 @@ object ActorMonitors {
     }
   }
 
-  class TrackedRoutee(routerMetrics: RouterMetrics, groupMetrics: Seq[ActorGroupMetrics], actorCellCreation: Boolean)
-      extends GroupMetricsTrackingActor(groupMetrics, actorCellCreation) {
+  class TrackedRoutee(routerMetrics: RouterMetrics, groupMetrics: Seq[ActorGroupMetrics], actorCellCreation: Boolean, cellInfo: CellInfo)
+      extends GroupMetricsTrackingActor(groupMetrics, actorCellCreation, cellInfo) {
 
-    def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext): AnyRef = {
+    def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext, envelope: Envelope): AnyRef = {
       val timestampBeforeProcessing = System.nanoTime()
+      Metrics.forSystem(cellInfo.systemName).processedMessagesByTracked.increment()
 
       try {
         Kamon.withContext(envelopeContext.context) {
           pjp.proceed()
         }
-
       } finally {
         val timestampAfterProcessing = System.nanoTime()
         val timeInMailbox = timestampBeforeProcessing - envelopeContext.nanoTime
@@ -145,7 +206,7 @@ object ActorMonitors {
     }
   }
 
-  abstract class GroupMetricsTrackingActor(groupMetrics: Seq[ActorGroupMetrics], actorCellCreation: Boolean) extends ActorMonitor {
+  abstract class GroupMetricsTrackingActor(groupMetrics: Seq[ActorGroupMetrics], actorCellCreation: Boolean, cellInfo: CellInfo) extends ActorMonitor {
     if (actorCellCreation) {
       groupMetrics.foreach { gm =>
         gm.members.increment()
@@ -175,6 +236,7 @@ object ActorMonitors {
     }
 
     def cleanup(): Unit = {
+      Metrics.forSystem(cellInfo.systemName).activeActors.decrement()
       if (actorCellCreation) {
         groupMetrics.foreach { gm =>
           gm.members.decrement()

--- a/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/DeadLettersInstrumentation.scala
+++ b/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/DeadLettersInstrumentation.scala
@@ -1,0 +1,51 @@
+package akka.kamon.instrumentation
+
+
+import akka.actor.{ActorSystem, DeadLetter, UnhandledMessage}
+import kamon.akka.Metrics
+import org.aspectj.lang.annotation.{After, Aspect, DeclareMixin, Pointcut}
+
+trait HasSystem {
+  def system: ActorSystem
+  def setSystem(system: ActorSystem): Unit
+}
+
+object HasSystem {
+  def apply(): HasSystem = new HasSystem {
+    private var _system: ActorSystem = _
+
+    override def system: ActorSystem = _system
+
+    override def setSystem(system: ActorSystem): Unit = _system = system
+  }
+}
+
+@Aspect
+class DeadLettersInstrumentation {
+
+  @DeclareMixin("akka.event.EventStream+")
+  def mixinHasSystem: HasSystem = HasSystem()
+
+  @Pointcut("execution(akka.event.EventStream.new(..)) && this(eventStream) && args(system, debug)")
+  def eventStreamCreation(eventStream: HasSystem, system: ActorSystem, debug: Boolean): Unit = {}
+
+  @After("eventStreamCreation(eventStream, system, debug)")
+  def aroundEventStreamCreateion(eventStream: HasSystem, system:ActorSystem, debug: Boolean): Unit = {
+    eventStream.setSystem(system)
+  }
+
+
+  @Pointcut("execution(* akka.event.EventStream.publish(..)) && this(stream) && args(event)")
+  def streamPublish(stream: HasSystem, event: AnyRef): Unit = {}
+
+  @After("streamPublish(stream, event)")
+  def afterStreamSubchannel(stream: HasSystem, event: AnyRef): Unit = trackEvent(stream, event)
+
+
+  private def trackEvent(stream: HasSystem, event: AnyRef): Unit = event match {
+    case dl: DeadLetter => Metrics.forSystem(stream.system.name).deadLetters.increment()
+    case um: UnhandledMessage => Metrics.forSystem(stream.system.name).unhandledMessages.increment()
+    case _ => ()
+  }
+
+}

--- a/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/DispatcherInstrumentation.scala
+++ b/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/DispatcherInstrumentation.scala
@@ -37,6 +37,14 @@ import scala.collection.concurrent.TrieMap
 class DispatcherInstrumentation {
   import DispatcherInstrumentation.registeredDispatchers
 
+  @Pointcut("execution(* akka.dispatch.ForkJoinExecutorConfigurator.ForkJoinExecutorServiceFactory.createExecutorService())")
+  def executorConstruction(): Unit = {}
+
+  @Around("executorConstruction()")
+  def aroundexecutorConstruction(pjp: ProceedingJoinPoint): ExecutorService = Executors.instrument(
+    pjp.proceed().asInstanceOf[ExecutorService]
+  )
+
   @Pointcut("execution(* akka.actor.ActorSystemImpl.start(..)) && this(system)")
   def actorSystemInitialization(system: ActorSystemImpl): Unit = {}
 

--- a/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/RouterMonitor.scala
+++ b/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/RouterMonitor.scala
@@ -20,7 +20,7 @@ object RouterMonitor {
     val cellInfo = CellInfo.cellInfoFor(cell, cell.system, cell.self, cell.parent, false)
 
     if (cellInfo.isTracked)
-      new MetricsOnlyRouterMonitor(Metrics.forRouter(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName))
+      new MetricsOnlyRouterMonitor(Metrics.forRouter(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName, cellInfo.actorClass))
     else NoOpRouterMonitor
   }
 }

--- a/kamon-akka-2.4.x/src/test/resources/application.conf
+++ b/kamon-akka-2.4.x/src/test/resources/application.conf
@@ -1,5 +1,5 @@
 akka {
-  loglevel = INFO
+  loglevel = DEBUG
   loggers = [ "akka.event.slf4j.Slf4jLogger" ]
   logger-startup-timeout = 30s
 }
@@ -48,9 +48,16 @@ kamon {
         includes = ["*/user/group-of-routees*"]
         excludes = []
       }
+
+      akka-tracing {
+        includes = [ "*/user/traced*" ]
+        excludes = []
+      }
     }
 
   }
+
+  trace.sampler = "always"
 
   default-instrument-settings {
     gauge.refresh-interval = 1 hour

--- a/kamon-akka-2.4.x/src/test/resources/application.conf
+++ b/kamon-akka-2.4.x/src/test/resources/application.conf
@@ -67,6 +67,9 @@ explicitly-excluded {
   executor = "fork-join-executor"
 }
 
+
+akka.actor.default-dispatcher.shutdown-timeout = 30s
+
 tracked-fjp {
   type = "Dispatcher"
   executor = "fork-join-executor"

--- a/kamon-akka-2.4.x/src/test/scala/kamon/akka/ActorMetricsSpec.scala
+++ b/kamon-akka-2.4.x/src/test/scala/kamon/akka/ActorMetricsSpec.scala
@@ -16,18 +16,14 @@
 package kamon.akka
 
 
-import java.nio.LongBuffer
-
 import scala.concurrent.duration._
 import org.scalatest.concurrent.Eventually
 import org.scalactic.TimesOnInt._
 import akka.actor._
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
-import kamon.Kamon
 import Metrics._
 import kamon.akka.ActorMetricsTestActor._
 import kamon.testkit.MetricInspection
-
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 
 class ActorMetricsSpec extends TestKit(ActorSystem("ActorMetricsSpec")) with WordSpecLike with MetricInspection with Matchers
@@ -115,13 +111,62 @@ class ActorMetricsSpec extends TestKit(ActorSystem("ActorMetricsSpec")) with Wor
     }
   }
 
+  "the Kamon system metrics" should {
+    val systemMetrics= Metrics.forSystem(system.name)
+    "record deadletters" in {
+      val doaActor = system.actorOf(Props[ActorMetricsTestActor], "doa")
+
+      val deathWatcher = TestProbe()
+      deathWatcher.watch(doaActor)
+      doaActor ! PoisonPill
+      deathWatcher.expectTerminated(doaActor)
+
+      (1 to 7).foreach(_ =>  doaActor ! "deadonarrival")
+      eventually {
+        systemMetrics.deadLetters.value(false).toInt should be(7)
+      }
+    }
+
+    "record unhandeled messages" in {
+      val hndl = system.actorOf(Props[ActorMetricsTestActor], "nonhandled")
+
+      (1 to 10).foreach(_ => hndl ! "CantHandleStrings")
+      eventually {
+        systemMetrics.unhandledMessages.value(false).toInt should be(10)
+      }
+    }
+
+    "record active actor counts" in {
+      systemMetrics.activeActors.distribution(true)
+      (1 to 8).foreach(i => system.actorOf(Props[ActorMetricsTestActor], s"counted-$i"))
+      eventually {
+        systemMetrics.activeActors.distribution(false).max.toInt should be > 0
+      }
+    }
+
+    "record processed messages counts" in {
+      systemMetrics.processedMessagesByTracked.value(true)
+      systemMetrics.processedMessagesByNonTracked.value(true)
+
+      val tracked = system.actorOf(Props[ActorMetricsTestActor], "tracked-actor-counts")
+      val nonTracked = system.actorOf(Props[ActorMetricsTestActor], "non-tracked-actor-counts")
+
+      (1 to 10).foreach(_ => tracked ! Discard)
+      (1 to 15).foreach(_ => nonTracked ! Discard)
+
+      eventually(systemMetrics.processedMessagesByTracked.value(false) should be(10))
+      eventually(systemMetrics.processedMessagesByNonTracked.value(false) should be(15))
+    }
+  }
+
   override protected def afterAll(): Unit = shutdown()
 
   def actorTags(path: String): Map[String, String] =
     Map(
       "path" -> path,
       "system" -> "ActorMetricsSpec",
-      "dispatcher" -> "akka.actor.default-dispatcher"
+      "dispatcher" -> "akka.actor.default-dispatcher",
+      "class" -> "kamon.akka.ActorMetricsTestActor"
     )
 
   trait ActorMetricsFixtures {

--- a/kamon-akka-2.4.x/src/test/scala/kamon/akka/DispatcherMetricsSpec.scala
+++ b/kamon-akka-2.4.x/src/test/scala/kamon/akka/DispatcherMetricsSpec.scala
@@ -29,32 +29,31 @@ import org.scalatest.concurrent.Eventually
 import scala.concurrent.Future
 
 class DispatcherMetricsSpec extends TestKit(ActorSystem("DispatcherMetricsSpec")) with WordSpecLike with MetricInspection with Matchers
-    with BeforeAndAfterAll with ImplicitSender with Eventually {
+  with BeforeAndAfterAll with ImplicitSender with Eventually {
 
   "the Kamon dispatcher metrics" should {
-    "track dispatchers configured in the akka.dispatcher filter" in {
-      forceInit(system.dispatchers.lookup("akka.actor.default-dispatcher"))
-      forceInit(system.dispatchers.lookup("tracked-fjp"))
-      forceInit(system.dispatchers.lookup("tracked-tpe"))
-      forceInit(system.dispatchers.lookup("explicitly-excluded"))
 
-      forkJoinPoolParallelism.valuesForTag("name") should contain only("akka.actor.default-dispatcher", "tracked-fjp")
-      threadPoolSize.valuesForTag("name") should contain only("tracked-tpe")
+    val dispatcherMetrics = Seq(Pool, Threads, Tasks, Queue)
+
+    val trackedDispatchers = Seq(
+      "akka.actor.default-dispatcher",
+      "tracked-fjp",
+      "tracked-tpe"
+    )
+    val allDispatchers = trackedDispatchers :+ "explicitly-excluded"
+
+    "track dispatchers configured in the akka.dispatcher filter" in {
+      allDispatchers.foreach(id => forceInit(system.dispatchers.lookup(id)))
+
+      val dispatcherMetricTags = dispatcherMetrics.map(_.partialRefineKeys(Set("name"))).flatten
+
+      trackedDispatchers.forall(d => dispatcherMetricTags.exists(_.get("name").get == d)) should be (true)
     }
 
-
     "clean up the metrics recorders after a dispatcher is shutdown" in {
-      implicit val tpeDispatcher = system.dispatchers.lookup("tracked-tpe")
-      implicit val fjpDispatcher = system.dispatchers.lookup("tracked-fjp")
-
-      forkJoinPoolParallelism.valuesForTag("name") should contain("tracked-fjp")
-      threadPoolSize.valuesForTag("name") should contain("tracked-tpe")
-
-      shutdownDispatcher(tpeDispatcher)
-      shutdownDispatcher(fjpDispatcher)
-
-      forkJoinPoolParallelism.valuesForTag("name") shouldNot contain("tracked-fjp")
-      threadPoolSize.valuesForTag("name") shouldNot contain("tracked-tpe")
+      Pool.valuesForTag("name") should contain("tracked-fjp")
+      shutdownDispatcher(system.dispatchers.lookup("tracked-fjp"))
+      Pool.valuesForTag("name") shouldNot contain("tracked-fjp")
     }
 
     "play nicely when dispatchers are looked up from a BalancingPool router" in {
@@ -62,8 +61,9 @@ class DispatcherMetricsSpec extends TestKit(ActorSystem("DispatcherMetricsSpec")
       balancingPoolRouter ! Ping
       expectMsg(Pong)
 
-      forkJoinPoolParallelism.valuesForTag("name") should contain("BalancingPool-/test-balancing-pool")
+      Pool.valuesForTag("name") should contain("BalancingPool-/test-balancing-pool")
     }
+
   }
 
 
@@ -76,10 +76,6 @@ class DispatcherMetricsSpec extends TestKit(ActorSystem("DispatcherMetricsSpec")
 
     dispatcher
   }
-
-  def submit(dispatcher: MessageDispatcher): Future[String] = Future {
-    "hello"
-  }(dispatcher)
 
   def shutdownDispatcher(dispatcher: MessageDispatcher): Unit = {
     val shutdownMethod = dispatcher.getClass.getDeclaredMethod("shutdown")

--- a/kamon-akka-2.4.x/src/test/scala/kamon/akka/instrumentation/MessageTracingSpec.scala
+++ b/kamon-akka-2.4.x/src/test/scala/kamon/akka/instrumentation/MessageTracingSpec.scala
@@ -1,0 +1,110 @@
+package kamon.akka.instrumentation
+
+import akka.actor.{Actor, ActorRef, ActorSystem, Props}
+import akka.routing.RoundRobinGroup
+import akka.testkit.{ImplicitSender, TestKit}
+import kamon.Kamon
+import kamon.testkit.{MetricInspection, SpanInspection}
+import kamon.trace.Span
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+
+
+class RootActor(tester: Option[ActorRef]) extends Actor with SpanInspection {
+
+  def currentSpan = Kamon.currentContext().get(Span.ContextKey)
+
+  override def receive: Receive = {
+    case (forwardTo: ActorRef, target: ActorRef) => {
+      tester.foreach(_ ! currentSpan)
+      forwardTo ! target
+    }
+    case forwardTo: ActorRef => {
+      tester.foreach(_ ! currentSpan)
+      forwardTo ! "span"
+    }
+    case "span" => {
+      tester.foreach(_ ! currentSpan)
+    }
+
+  }
+}
+
+class MessageTracingSpec extends TestKit(ActorSystem("MessageTracing")) with WordSpecLike with MetricInspection with Matchers with SpanInspection
+  with BeforeAndAfterAll with ImplicitSender with Eventually {
+
+  "Message tracing instrumentation" should {
+
+    "skip filtered out actors" in {
+      val traced = system.actorOf(Props(classOf[RootActor], Some(testActor)), "filteredout")
+      traced ! "span"
+      assert(expectMsgType[Span] == Span.Empty)
+    }
+
+    "construct span for traced actors" in {
+      val traced = system.actorOf(Props(classOf[RootActor], Some(testActor)), "traced")
+      traced ! "span"
+      val spanCtx = inspect(expectMsgType[Span]).context()
+      assert(spanCtx.parentID.string.isEmpty)
+      assert(spanCtx.spanID.string.nonEmpty)
+      assert(spanCtx.traceID.string.nonEmpty)
+    }
+
+    "create child spans for messages between traced actors" in {
+      val root = system.actorOf(Props(classOf[RootActor], Some(testActor)), "traced-root")
+      val child = system.actorOf(Props(classOf[RootActor], Some(testActor)), "traced-child")
+
+      root ! child
+
+      val rootSpan = inspect(expectMsgType[Span]).context()
+      val childSpan = inspect(expectMsgType[Span]).context()
+
+      assert(rootSpan.parentID.string.isEmpty)
+      assert(childSpan.parentID.string == rootSpan.spanID.string)
+    }
+
+    "create hierarchy of spans even across propagation-only actors" in {
+      val root = system.actorOf(Props(classOf[RootActor], Some(testActor)), "traced-chain-root")
+      val noninstrumented = system.actorOf(Props(classOf[RootActor], Some(testActor)), "filteredout-child")
+      val child = system.actorOf(Props(classOf[RootActor], Some(testActor)), "traced-chain-child")
+
+      root ! (noninstrumented, child)
+
+      val rootSpan = inspect(expectMsgType[Span]).context()
+      val nonInstrumented = inspect(expectMsgType[Span]).context()
+      val childSpan = inspect(expectMsgType[Span]).context()
+
+      assert(rootSpan.parentID.string.isEmpty)
+      assert(nonInstrumented.spanID.string == rootSpan.spanID.string)
+      assert(childSpan.parentID.string == rootSpan.spanID.string)
+    }
+
+    "create routee spans as child of original when router is not traced" in {
+      val root = system.actorOf(Props(classOf[RootActor], Some(testActor)),"traced-router-root")
+      val routee = system.actorOf(Props(classOf[RootActor], Some(testActor)),"traced-routee-one")
+      val router = system.actorOf(RoundRobinGroup(Vector(routee.path.toStringWithoutAddress)).props(), "nontraced-pool-router")
+
+      root ! router
+
+      val rootSpan = inspect(expectMsgType[Span]).context()
+      val routeeOne = inspect(expectMsgType[Span]).context()
+
+      assert(rootSpan.spanID.string == routeeOne.parentID.string)
+    }
+
+    "create parent-child spans for router-routee when both are traced" in {
+      val routee = system.actorOf(Props(classOf[RootActor], Some(testActor)),"traced-routee")
+      val router = system.actorOf(RoundRobinGroup(Vector(routee.path.toStringWithoutAddress)).props(), "traced-pool-router")
+
+      router ! "span"
+
+      val routeeSpan = inspect(expectMsgType[Span]).context()
+
+      assert(routeeSpan.parentID.string.nonEmpty)
+    }
+
+  }
+
+
+
+}

--- a/kamon-akka-2.5.x/src/main/resources/META-INF/aop.xml
+++ b/kamon-akka-2.5.x/src/main/resources/META-INF/aop.xml
@@ -14,6 +14,8 @@
     <aspect name="akka.kamon.instrumentation.RoutedActorCellInstrumentation"/>
     <aspect name="akka.kamon.instrumentation.ActorLoggingInstrumentation"/>
 
+    <aspect name="akka.kamon.instrumentation.DeadLettersInstrumentation"/>
+
     <!-- Dispatchers -->
     <aspect name="akka.kamon.instrumentation.DispatcherInstrumentation"/>
     <aspect name="akka.kamon.instrumentation.DispatcherMetricCollectionInfoIntoDispatcherMixin"/>

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/Akka.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/Akka.scala
@@ -25,6 +25,7 @@ object Akka {
   val ActorFilterName = "akka.actor"
   val RouterFilterName = "akka.router"
   val DispatcherFilterName = "akka.dispatcher"
+  val ActorTracingFilterName = "akka-tracing"
 
   @volatile var askPatternTimeoutWarning: AskPatternTimeoutWarningSetting = Off
   @volatile var actorGroups = Seq.empty[String]

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/Metrics.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/Metrics.scala
@@ -38,10 +38,10 @@ object Metrics {
   val actorMailboxSizeMetric = Kamon.minMaxCounter("akka.actor.mailbox-size")
   val actorErrorsMetric = Kamon.counter("akka.actor.errors")
 
-  def forActor(path: String, system: String, dispatcher: String): ActorMetrics = {
-    val actorTags = Map("path" -> path, "system" -> system, "dispatcher" -> dispatcher)
+  def forActor(path: String, system: String, dispatcher: String, actorClass: String): ActorMetrics = {
+    val actorTags = Map("path" -> path, "system" -> system, "dispatcher" -> dispatcher, "class" -> actorClass)
     ActorMetrics(
-      actorTags,
+    actorTags,
       actorTimeInMailboxMetric.refine(actorTags),
       actorProcessingTimeMetric.refine(actorTags),
       actorMailboxSizeMetric.refine(actorTags),
@@ -76,7 +76,7 @@ object Metrics {
   val routerProcessingTime = Kamon.histogram("akka.router.processing-time", time.nanoseconds)
   val routerErrors = Kamon.counter("akka.router.errors")
 
-  def forRouter(path: String, system: String, dispatcher: String): RouterMetrics = {
+  def forRouter(path: String, system: String, dispatcher: String, actorClass: String): RouterMetrics = {
     val routerTags = Map("path" -> path, "system" -> system, "dispatcher" -> dispatcher)
     RouterMetrics(
       routerTags,
@@ -138,6 +138,44 @@ object Metrics {
       groupMailboxSize.remove(tags)
       groupMembers.remove(tags)
       groupErrors.remove(tags)
+    }
+  }
+
+
+
+  /**
+    *
+    *  Metrics for actor systems.
+    *
+    *    - dead-letters: System global counter for messages received by dead letters.
+    *    - processed-messages: System global count of processed messages (separate for tracked and non-tracked)
+    *    - active-actors: Current count of active actors in the system.
+    */
+  val systemDeadLetters = Kamon.counter("akka.system.dead-letters")
+  val systemUnhandledMessages = Kamon.counter("akka.system.unhandled-messages")
+  val systemProcessedMessages = Kamon.counter("akka.system.processed-messages")
+  val systemActiveActors = Kamon.minMaxCounter("akka.system.active-actors")
+
+  def forSystem(name: String): ActorSystemMetrics = {
+    val systemTags = Map("system" -> name)
+    ActorSystemMetrics(
+      systemTags,
+      systemDeadLetters.refine(systemTags),
+      systemUnhandledMessages.refine(systemTags),
+      systemProcessedMessages.refine(systemTags + ("tracked" -> "true")),
+      systemProcessedMessages.refine(systemTags + ("tracked" -> "false")),
+      systemActiveActors.refine(systemTags)
+    )
+  }
+
+  case class ActorSystemMetrics(tags: Map[String, String], deadLetters: Counter, unhandledMessages: Counter, processedMessagesByTracked: Counter, processedMessagesByNonTracked: Counter, activeActors: MinMaxCounter) {
+    def cleanup(): Unit = {
+      systemDeadLetters.remove(tags)
+      systemUnhandledMessages.remove(tags)
+      systemActiveActors.remove(tags)
+      systemProcessedMessages.remove(tags + ("tracked" -> "true"))
+      systemProcessedMessages.remove(tags + ("tracked" -> "false"))
+
     }
   }
 }

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/ActorInstrumentation.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/ActorInstrumentation.scala
@@ -42,7 +42,7 @@ class ActorCellInstrumentation {
 
   @Around("invokingActorBehaviourAtActorCell(cell, envelope)")
   def aroundBehaviourInvoke(pjp: ProceedingJoinPoint, cell: ActorCell, envelope: Envelope): Any = {
-    actorInstrumentation(cell).processMessage(pjp, envelope.asInstanceOf[InstrumentedEnvelope].timestampedContext())
+    actorInstrumentation(cell).processMessage(pjp, envelope.asInstanceOf[InstrumentedEnvelope].timestampedContext(), envelope)
   }
 
   @Pointcut("execution(* akka.actor.ActorCell.terminate()) && this(cell)")

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/ActorMonitor.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/ActorMonitor.scala
@@ -1,46 +1,54 @@
 package akka.kamon.instrumentation
 
 import akka.actor.{ActorRef, ActorSystem, Cell}
-import akka.kamon.instrumentation.ActorMonitors.{TrackedActor, TrackedRoutee}
+import akka.dispatch.Envelope
+import akka.kamon.instrumentation.ActorMonitors.{TracedMonitor, TrackedActor, TrackedRoutee}
 import kamon.Kamon
 import kamon.akka.Metrics
 import kamon.akka.Metrics.{ActorGroupMetrics, ActorMetrics, RouterMetrics}
+import kamon.context.Context
+import kamon.trace.Span
 import org.aspectj.lang.ProceedingJoinPoint
 
 trait ActorMonitor {
   def captureEnvelopeContext(): TimestampedContext
-  def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext): AnyRef
+  def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext, envelope: Envelope): AnyRef
   def processFailure(failure: Throwable): Unit
   def cleanup(): Unit
 }
+
 
 object ActorMonitor {
 
   def createActorMonitor(cell: Cell, system: ActorSystem, ref: ActorRef, parent: ActorRef, actorCellCreation: Boolean): ActorMonitor = {
     val cellInfo = CellInfo.cellInfoFor(cell, system, ref, parent, actorCellCreation)
 
-    if (cellInfo.isRouter)
-      ActorMonitors.ContextPropagationOnly
+    Metrics.forSystem(system.name).activeActors.increment()
+
+    val monitor = if (cellInfo.isRouter)
+      ActorMonitors.ContextPropagationOnly(cellInfo)
     else {
       if (cellInfo.isRoutee && cellInfo.isTracked)
         createRouteeMonitor(cellInfo)
       else
         createRegularActorMonitor(cellInfo)
     }
+
+    if(cellInfo.isTraced) new TracedMonitor(cellInfo, monitor) else monitor
   }
 
   def createRegularActorMonitor(cellInfo: CellInfo): ActorMonitor = {
     if (cellInfo.isTracked || !cellInfo.trackingGroups.isEmpty) {
-      val actorMetrics = if (cellInfo.isTracked) Some(Metrics.forActor(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName)) else None
-      new TrackedActor(actorMetrics, trackingGroupMetrics(cellInfo), cellInfo.actorCellCreation)
+      val actorMetrics = if (cellInfo.isTracked) Some(Metrics.forActor(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName, cellInfo.actorClass)) else None
+      new TrackedActor(actorMetrics, trackingGroupMetrics(cellInfo), cellInfo.actorCellCreation, cellInfo)
     } else {
-      ActorMonitors.ContextPropagationOnly
+      ActorMonitors.ContextPropagationOnly(cellInfo)
     }
   }
 
   def createRouteeMonitor(cellInfo: CellInfo): ActorMonitor = {
-    val routerMetrics = Metrics.forRouter(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName)
-    new TrackedRoutee(routerMetrics, trackingGroupMetrics(cellInfo), cellInfo.actorCellCreation)
+    val routerMetrics = Metrics.forRouter(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName, cellInfo.actorClass)
+    new TrackedRoutee(routerMetrics, trackingGroupMetrics(cellInfo), cellInfo.actorCellCreation, cellInfo)
   }
 
   private def trackingGroupMetrics(cellInfo: CellInfo): Seq[ActorGroupMetrics] = {
@@ -52,23 +60,76 @@ object ActorMonitor {
 
 object ActorMonitors {
 
-  val ContextPropagationOnly = new ActorMonitor {
-    def captureEnvelopeContext(): TimestampedContext =
-      TimestampedContext(0, Kamon.currentContext())
+  class TracedMonitor(cellInfo: CellInfo, monitor: ActorMonitor) extends ActorMonitor {
 
-    def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext): AnyRef = {
+    override def captureEnvelopeContext(): TimestampedContext = {
+      val currCtx = Kamon.currentContext()
+      val currSpan = currCtx.get(Span.ContextKey)
+      val newSpan = Kamon.buildSpan(cellInfo.actorName)
+        .asChildOf(currSpan)
+        .start()
+        .mark("enqueued")
+
+      monitor.captureEnvelopeContext().copy(
+        context = currCtx.withKey(Span.ContextKey, newSpan)
+      )
+    }
+
+    override def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext, envelope: Envelope): AnyRef = {
+      tagSpan(cellInfo, envelope, envelopeContext.context)
+      val res = monitor.processMessage(pjp, envelopeContext, envelope)
+      finishSpan(envelopeContext.context)
+      res
+    }
+
+    override def processFailure(failure: Throwable): Unit = monitor.processFailure(failure)
+
+    override def cleanup(): Unit = monitor.cleanup()
+
+    private def tagSpan(cellInfo: CellInfo, envelope: Envelope, context: Context) = {
+      val span = context.get(Span.ContextKey)
+      val messageClass = envelope.message.getClass.getSimpleName
+
+      span.setOperationName(s"${cellInfo.actorName}.$messageClass")
+
+      span.mark("dequeued")
+
+      span.tag("path", cellInfo.path)
+      span.tag("system", cellInfo.systemName)
+      span.tag("actor-class", cellInfo.actorClass)
+      span.tag("message-class", messageClass)
+    }
+
+    private def finishSpan(context: Context) = {
+      val span = context.get(Span.ContextKey)
+      span.mark("processed")
+      span.finish()
+    }
+
+  }
+
+
+  def ContextPropagationOnly(cellInfo: CellInfo) = new ActorMonitor {
+    def captureEnvelopeContext(): TimestampedContext = TimestampedContext(0, Kamon.currentContext())//tracedContext(cellInfo.isTracked, cellInfo.traced, Kamon.currentContext())
+
+    def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext, envelope: Envelope): AnyRef = {
+      Metrics.forSystem(cellInfo.systemName).processedMessagesByNonTracked.increment()
+
       Kamon.withContext(envelopeContext.context) {
         pjp.proceed()
       }
     }
 
     def processFailure(failure: Throwable): Unit = {}
-    def cleanup(): Unit = {}
-
+    def cleanup(): Unit = {
+      Metrics.forSystem(cellInfo.systemName).activeActors.decrement()
+    }
   }
 
-  class TrackedActor(actorMetrics: Option[ActorMetrics], groupMetrics: Seq[ActorGroupMetrics], actorCellCreation: Boolean)
-      extends GroupMetricsTrackingActor(groupMetrics, actorCellCreation) {
+
+
+  class TrackedActor(actorMetrics: Option[ActorMetrics], groupMetrics: Seq[ActorGroupMetrics], actorCellCreation: Boolean, cellInfo: CellInfo)
+      extends GroupMetricsTrackingActor(groupMetrics, actorCellCreation, cellInfo) {
 
     override def captureEnvelopeContext(): TimestampedContext = {
       actorMetrics.foreach { am =>
@@ -77,14 +138,14 @@ object ActorMonitors {
       super.captureEnvelopeContext()
     }
 
-    def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext): AnyRef = {
+    def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext, envelope: Envelope): AnyRef = {
       val timestampBeforeProcessing = System.nanoTime()
+      Metrics.forSystem(cellInfo.systemName).processedMessagesByTracked.increment()
 
       try {
         Kamon.withContext(envelopeContext.context) {
           pjp.proceed()
         }
-
       } finally {
         val timestampAfterProcessing = System.nanoTime()
         val timeInMailbox = timestampBeforeProcessing - envelopeContext.nanoTime
@@ -112,17 +173,17 @@ object ActorMonitors {
     }
   }
 
-  class TrackedRoutee(routerMetrics: RouterMetrics, groupMetrics: Seq[ActorGroupMetrics], actorCellCreation: Boolean)
-      extends GroupMetricsTrackingActor(groupMetrics, actorCellCreation) {
+  class TrackedRoutee(routerMetrics: RouterMetrics, groupMetrics: Seq[ActorGroupMetrics], actorCellCreation: Boolean, cellInfo: CellInfo)
+      extends GroupMetricsTrackingActor(groupMetrics, actorCellCreation, cellInfo) {
 
-    def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext): AnyRef = {
+    def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext, envelope: Envelope): AnyRef = {
       val timestampBeforeProcessing = System.nanoTime()
+      Metrics.forSystem(cellInfo.systemName).processedMessagesByTracked.increment()
 
       try {
         Kamon.withContext(envelopeContext.context) {
           pjp.proceed()
         }
-
       } finally {
         val timestampAfterProcessing = System.nanoTime()
         val timeInMailbox = timestampBeforeProcessing - envelopeContext.nanoTime
@@ -145,7 +206,7 @@ object ActorMonitors {
     }
   }
 
-  abstract class GroupMetricsTrackingActor(groupMetrics: Seq[ActorGroupMetrics], actorCellCreation: Boolean) extends ActorMonitor {
+  abstract class GroupMetricsTrackingActor(groupMetrics: Seq[ActorGroupMetrics], actorCellCreation: Boolean, cellInfo: CellInfo) extends ActorMonitor {
     if (actorCellCreation) {
       groupMetrics.foreach { gm =>
         gm.members.increment()
@@ -175,6 +236,7 @@ object ActorMonitors {
     }
 
     def cleanup(): Unit = {
+      Metrics.forSystem(cellInfo.systemName).activeActors.decrement()
       if (actorCellCreation) {
         groupMetrics.foreach { gm =>
           gm.members.decrement()

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/DeadLettersInstrumentation.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/DeadLettersInstrumentation.scala
@@ -1,0 +1,51 @@
+package akka.kamon.instrumentation
+
+
+import akka.actor.{ActorSystem, DeadLetter, UnhandledMessage}
+import kamon.akka.Metrics
+import org.aspectj.lang.annotation.{After, Aspect, DeclareMixin, Pointcut}
+
+trait HasSystem {
+  def system: ActorSystem
+  def setSystem(system: ActorSystem): Unit
+}
+
+object HasSystem {
+  def apply(): HasSystem = new HasSystem {
+    private var _system: ActorSystem = _
+
+    override def system: ActorSystem = _system
+
+    override def setSystem(system: ActorSystem): Unit = _system = system
+  }
+}
+
+@Aspect
+class DeadLettersInstrumentation {
+
+  @DeclareMixin("akka.event.EventStream+")
+  def mixinHasSystem: HasSystem = HasSystem()
+
+  @Pointcut("execution(akka.event.EventStream.new(..)) && this(eventStream) && args(system, debug)")
+  def eventStreamCreation(eventStream: HasSystem, system: ActorSystem, debug: Boolean): Unit = {}
+
+  @After("eventStreamCreation(eventStream, system, debug)")
+  def aroundEventStreamCreateion(eventStream: HasSystem, system:ActorSystem, debug: Boolean): Unit = {
+    eventStream.setSystem(system)
+  }
+
+
+  @Pointcut("execution(* akka.event.EventStream.publish(..)) && this(stream) && args(event)")
+  def streamPublish(stream: HasSystem, event: AnyRef): Unit = {}
+
+  @After("streamPublish(stream, event)")
+  def afterStreamSubchannel(stream: HasSystem, event: AnyRef): Unit = trackEvent(stream, event)
+
+
+  private def trackEvent(stream: HasSystem, event: AnyRef): Unit = event match {
+    case dl: DeadLetter => Metrics.forSystem(stream.system.name).deadLetters.increment()
+    case um: UnhandledMessage => Metrics.forSystem(stream.system.name).unhandledMessages.increment()
+    case _ => ()
+  }
+
+}

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/RouterMonitor.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/RouterMonitor.scala
@@ -20,7 +20,7 @@ object RouterMonitor {
     val cellInfo = CellInfo.cellInfoFor(cell, cell.system, cell.self, cell.parent, false)
 
     if (cellInfo.isTracked)
-      new MetricsOnlyRouterMonitor(Metrics.forRouter(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName))
+      new MetricsOnlyRouterMonitor(Metrics.forRouter(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName, cellInfo.actorClass))
     else NoOpRouterMonitor
   }
 }

--- a/kamon-akka-2.5.x/src/test/resources/application.conf
+++ b/kamon-akka-2.5.x/src/test/resources/application.conf
@@ -48,9 +48,16 @@ kamon {
         includes = ["*/user/group-of-routees*"]
         excludes = []
       }
+
+      akka-tracing {
+        includes = [ "*/user/traced*" ]
+        excludes = []
+      }
     }
 
   }
+
+  trace.sampler = "always"
 
   default-instrument-settings {
     gauge.refresh-interval = 1 hour

--- a/kamon-akka-2.5.x/src/test/scala/kamon/akka/ExecutorMetricsSpec.scala
+++ b/kamon-akka-2.5.x/src/test/scala/kamon/akka/ExecutorMetricsSpec.scala
@@ -1,0 +1,188 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.akka
+
+import java.util.UUID
+
+import kamon.testkit.MetricInspection
+import org.scalatest.{Matchers, WordSpec}
+import java.util.concurrent.{ExecutorService, ForkJoinPool, ThreadPoolExecutor, Executors => JavaExecutors}
+
+import kamon.executors.Executors
+import kamon.executors.Executors.InstrumentedExecutorService
+import kamon.executors.Metrics._
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{Millis, Span}
+import akka.dispatch.forkjoin.{ForkJoinPool => AkkaForkJoinPool}
+import akka.kamon.instrumentation.DispatcherInstrumentation
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future, Promise}
+
+
+class ExecutorMetricsSpec extends WordSpec with Matchers with MetricInspection with Eventually {
+
+
+  implicit override val patienceConfig =
+    PatienceConfig(timeout = scaled(Span(2000, Millis)), interval = scaled(Span(20, Millis)))
+
+  class ExecutorMetrics(name: String, tpe: String) {
+    private val poolTags = Map(
+      "name" -> name,
+      "type" -> tpe
+    )
+    def poolMin(reset: Boolean = false) = Pool.refine(poolTags + ("setting" -> "min")).value(reset)
+    def poolMax(reset: Boolean = false) = Pool.refine(poolTags + ("setting" -> "max")).value(reset)
+
+    def threadsTotal(reset: Boolean = false) = Threads.refine(poolTags + ("state" -> "total")).distribution(reset)
+    def threadsActive(reset: Boolean = false) = Threads.refine(poolTags + ("state" -> "active")).distribution(reset)
+
+    def tasksSubmitted(reset: Boolean = false) = Tasks.refine(poolTags + ("state" -> "submitted")).value(reset)
+    def tasksCompleted(reset: Boolean = false) = Tasks.refine(poolTags + ("state" -> "completed")).value(reset)
+
+    def queue(reset: Boolean = false) = Queue.refine(poolTags).distribution(reset)
+
+    def poolParallelism(reset: Boolean = false) = Pool.refine(poolTags + ("setting" -> "parallelism")).value(reset)
+
+    def poolCoreSize(reset: Boolean = false) = Pool.refine(poolTags + ("setting" ->  "corePoolSize")).value(reset)
+  }
+
+  "the ExecutorServiceMetrics" should {
+
+    "register an Akka ForkJoinPool, collect their metrics and remove it" in {
+      val scalaForkJoinPool = Executors.instrument(new scala.concurrent.forkjoin.ForkJoinPool(10))
+      val registeredForkJoin = Executors.register("akka-fork-join-pool", scalaForkJoinPool)
+
+      Threads.valuesForTag("name")  should contain ("akka-fork-join-pool")
+      Threads.valuesForTag("type")  should contain ("fjp")
+
+      registeredForkJoin.cancel()
+    }
+
+  }
+
+  def setupTestPool(executor: ExecutorService): (ExecutorService, ExecutorMetrics) = {
+    implicit val fjpMetrics = DispatcherInstrumentation.AkkaFJPMetrics
+
+    val pool = new InstrumentedExecutorService[AkkaForkJoinPool](executor.asInstanceOf[AkkaForkJoinPool])
+    val name = s"testExecutor-${UUID.randomUUID()}"
+    val registered = Executors.register(name, pool)
+    val metrics = new ExecutorMetrics(name, "fjp")
+    (pool, metrics)
+  }
+
+
+
+  def commonExecutorMetrics(executor: Int => ExecutorService, size: Int) = {
+    "track settings" in {
+      val (pool, metrics) = setupTestPool(executor(size))
+      eventually(metrics.poolMax() should be (size))
+    }
+
+    "track tasks" in {
+      val (pool, metrics) = setupTestPool(executor(size))
+      val semaphore = Promise[String]()
+
+      eventually {
+        metrics.tasksSubmitted()      should be (0)
+        metrics.tasksCompleted()      should be (0)
+      }
+
+      val blockedTask = new Runnable {
+        override def run(): Unit = {
+          Await.result(semaphore.future, Duration.Inf)
+          ()
+        }}
+
+      pool.submit(blockedTask)
+      eventually {
+        (metrics.tasksSubmitted(), metrics.tasksCompleted()) should be (1, 0)
+      }
+
+      semaphore.success("done")
+      eventually {
+        (metrics.tasksSubmitted(), metrics.tasksCompleted()) should be (1, 1)
+      }
+
+      (1 to 10).foreach(_ => pool.submit(blockedTask))
+      eventually {
+        (metrics.tasksSubmitted(), metrics.tasksCompleted()) should be (11, 11)
+      }
+    }
+
+    "track threads" in {
+      val (pool, metrics) = setupTestPool(executor(2))
+
+      eventually {
+        metrics.threadsTotal().max should be (0)
+        metrics.threadsActive().max should be (0)
+      }
+
+      Future(
+        (1 to 10000).foreach(_ => pool.submit(new Runnable {
+          override def run(): Unit = Thread.sleep(1)
+        }))
+      )(scala.concurrent.ExecutionContext.global)
+
+      eventually {
+        metrics.threadsActive().max should be (2)
+        metrics.threadsTotal().max should be (2)
+      }
+    }
+
+    "track queue" in {
+      val (pool, metrics) = setupTestPool(executor(size))
+
+      val semaphore = Promise[String]()
+      val blockedTask = new Runnable {
+        override def run(): Unit = {
+          Await.result(semaphore.future, Duration.Inf)
+          ()
+        }}
+
+      eventually(metrics.queue().max should be (0))
+
+      (1 to 100).foreach(_ => pool.submit(blockedTask))
+
+      pool.submit(blockedTask)
+      eventually {
+        val queue = metrics.queue().max
+        val activeThreads = metrics.threadsActive().max
+        metrics.queue().max should be >= (100 - activeThreads)
+      }
+    }
+  }
+
+  def fjpMetrics(executor: Int => ExecutorService, size: Int) = {
+    val (pool, metrics) = setupTestPool(executor(size))
+    "track FJP specific matrics" in {
+      eventually {
+        metrics.poolParallelism() should be (size)
+        metrics.poolMin() should be (0)
+      }
+    }
+  }
+
+  "Executor service" when {
+    "backed by Akka FJP" should {
+      behave like commonExecutorMetrics(new akka.dispatch.forkjoin.ForkJoinPool(_), 10)
+      behave like fjpMetrics(new akka.dispatch.forkjoin.ForkJoinPool(_), 10)
+    }
+  }
+
+}
+

--- a/kamon-akka-2.5.x/src/test/scala/kamon/akka/instrumentation/MessageTracingSpec.scala
+++ b/kamon-akka-2.5.x/src/test/scala/kamon/akka/instrumentation/MessageTracingSpec.scala
@@ -1,0 +1,110 @@
+package kamon.akka.instrumentation
+
+import akka.actor.{Actor, ActorRef, ActorSystem, Props}
+import akka.routing.RoundRobinGroup
+import akka.testkit.{ImplicitSender, TestKit}
+import kamon.Kamon
+import kamon.testkit.{MetricInspection, SpanInspection}
+import kamon.trace.Span
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+
+
+class RootActor(tester: Option[ActorRef]) extends Actor with SpanInspection {
+
+  def currentSpan = Kamon.currentContext().get(Span.ContextKey)
+
+  override def receive: Receive = {
+    case (forwardTo: ActorRef, target: ActorRef) => {
+      tester.foreach(_ ! currentSpan)
+      forwardTo ! target
+    }
+    case forwardTo: ActorRef => {
+      tester.foreach(_ ! currentSpan)
+      forwardTo ! "span"
+    }
+    case "span" => {
+      tester.foreach(_ ! currentSpan)
+    }
+
+  }
+}
+
+class MessageTracingSpec extends TestKit(ActorSystem("MessageTracing")) with WordSpecLike with MetricInspection with Matchers with SpanInspection
+  with BeforeAndAfterAll with ImplicitSender with Eventually {
+
+  "Message tracing instrumentation" should {
+
+    "skip filtered out actors" in {
+      val traced = system.actorOf(Props(classOf[RootActor], Some(testActor)), "filteredout")
+      traced ! "span"
+      assert(expectMsgType[Span] == Span.Empty)
+    }
+
+    "construct span for traced actors" in {
+      val traced = system.actorOf(Props(classOf[RootActor], Some(testActor)), "traced")
+      traced ! "span"
+      val spanCtx = inspect(expectMsgType[Span]).context()
+      assert(spanCtx.parentID.string.isEmpty)
+      assert(spanCtx.spanID.string.nonEmpty)
+      assert(spanCtx.traceID.string.nonEmpty)
+    }
+
+    "create child spans for messages between traced actors" in {
+      val root = system.actorOf(Props(classOf[RootActor], Some(testActor)), "traced-root")
+      val child = system.actorOf(Props(classOf[RootActor], Some(testActor)), "traced-child")
+
+      root ! child
+
+      val rootSpan = inspect(expectMsgType[Span]).context()
+      val childSpan = inspect(expectMsgType[Span]).context()
+
+      assert(rootSpan.parentID.string.isEmpty)
+      assert(childSpan.parentID.string == rootSpan.spanID.string)
+    }
+
+    "create hierarchy of spans even across propagation-only actors" in {
+      val root = system.actorOf(Props(classOf[RootActor], Some(testActor)), "traced-chain-root")
+      val noninstrumented = system.actorOf(Props(classOf[RootActor], Some(testActor)), "filteredout-child")
+      val child = system.actorOf(Props(classOf[RootActor], Some(testActor)), "traced-chain-child")
+
+      root ! (noninstrumented, child)
+
+      val rootSpan = inspect(expectMsgType[Span]).context()
+      val nonInstrumented = inspect(expectMsgType[Span]).context()
+      val childSpan = inspect(expectMsgType[Span]).context()
+
+      assert(rootSpan.parentID.string.isEmpty)
+      assert(nonInstrumented.spanID.string == rootSpan.spanID.string)
+      assert(childSpan.parentID.string == rootSpan.spanID.string)
+    }
+
+    "create routee spans as child of original when router is not traced" in {
+      val root = system.actorOf(Props(classOf[RootActor], Some(testActor)),"traced-router-root")
+      val routee = system.actorOf(Props(classOf[RootActor], Some(testActor)),"traced-routee-one")
+      val router = system.actorOf(RoundRobinGroup(Vector(routee.path.toStringWithoutAddress)).props(), "nontraced-pool-router")
+
+      root ! router
+
+      val rootSpan = inspect(expectMsgType[Span]).context()
+      val routeeOne = inspect(expectMsgType[Span]).context()
+
+      assert(rootSpan.spanID.string == routeeOne.parentID.string)
+    }
+
+    "create parent-child spans for router-routee when both are traced" in {
+      val routee = system.actorOf(Props(classOf[RootActor], Some(testActor)),"traced-routee")
+      val router = system.actorOf(RoundRobinGroup(Vector(routee.path.toStringWithoutAddress)).props(), "traced-pool-router")
+
+      router ! "span"
+
+      val routeeSpan = inspect(expectMsgType[Span]).context()
+
+      assert(routeeSpan.parentID.string.nonEmpty)
+    }
+
+  }
+
+
+
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
-version in ThisBuild := "1.0.0-RC1-SNAPSHOT"
+version in ThisBuild := "1.0.0-RC3-SNAPSHOT"
 


### PR DESCRIPTION
- Actor message tracing
- Actor-system-wide metrics (processed messages, deadletters, unhandled messages, active actors)
- Instrument EventStream to intercept and track submission of DeadLetter and UnhandledMessage
- Migrated to Kamon-1.0 for all akka versions
