### PR TITLE
Transient context

### DIFF
--- a/kamon-akka-2.3.x/src/main/scala/kamon/akka/context/HasTransientContext.scala
+++ b/kamon-akka-2.3.x/src/main/scala/kamon/akka/context/HasTransientContext.scala
@@ -1,0 +1,25 @@
+package kamon.akka.context
+
+import kamon.Kamon
+import kamon.context.{Context, HasContext}
+
+object HasTransientContext {
+
+  private case class DefaultTransient(@transient context: Context) extends HasContext
+
+  /**
+    * Construct a HasSpan instance that references the provided Context.
+    *
+    */
+  def from(context: Context): HasContext =
+    DefaultTransient(context)
+
+  /**
+    * Construct a HasContext instance with the current Kamon from Kamon's default context storage.
+    *
+    */
+  def fromCurrentContext(): HasContext =
+    DefaultTransient(Kamon.currentContext())
+
+}
+

--- a/kamon-akka-2.3.x/src/main/scala/kamon/akka/instrumentation/ActorLoggingInstrumentation.scala
+++ b/kamon-akka-2.3.x/src/main/scala/kamon/akka/instrumentation/ActorLoggingInstrumentation.scala
@@ -17,6 +17,7 @@
 package akka.kamon.instrumentation
 
 import kamon.Kamon
+import kamon.akka.context.HasTransientContext
 import kamon.context.HasContext
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation._
@@ -25,7 +26,7 @@ import org.aspectj.lang.annotation._
 class ActorLoggingInstrumentation  {
 
   @DeclareMixin("akka.event.Logging.LogEvent+")
-  def mixinHasContextToLogEvent: HasContext = HasContext.fromCurrentContext()
+  def mixinHasContextToLogEvent: HasContext = HasTransientContext.fromCurrentContext()
 
   @Pointcut("execution(akka.event.Logging.LogEvent+.new(..)) && this(event)")
   def logEventCreation(event: HasContext): Unit = {}

--- a/kamon-akka-2.3.x/src/main/scala/kamon/akka/instrumentation/ActorSystemMessageInstrumentation.scala
+++ b/kamon-akka-2.3.x/src/main/scala/kamon/akka/instrumentation/ActorSystemMessageInstrumentation.scala
@@ -18,6 +18,7 @@ package akka.kamon.instrumentation
 
 import akka.dispatch.sysmsg.EarliestFirstSystemMessageList
 import kamon.Kamon
+import kamon.akka.context.HasTransientContext
 import kamon.context.HasContext
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation._
@@ -42,7 +43,7 @@ class ActorSystemMessageInstrumentation {
 class HasContextIntoSystemMessageMixin {
 
   @DeclareMixin("akka.dispatch.sysmsg.SystemMessage+")
-  def mixinHasContextToSystemMessage: HasContext = HasContext.fromCurrentContext()
+  def mixinHasContextToSystemMessage: HasContext = HasTransientContext.fromCurrentContext()
 
   @Pointcut("execution(akka.dispatch.sysmsg.SystemMessage+.new(..)) && this(message)")
   def systemMessageCreation(message: HasContext): Unit = {}
@@ -58,7 +59,7 @@ class HasContextIntoSystemMessageMixin {
 class HasContextIntoRepointableActorRefMixin {
 
   @DeclareMixin("akka.actor.RepointableActorRef")
-  def mixinHasContextToRepointableActorRef: HasContext = HasContext.fromCurrentContext()
+  def mixinHasContextToRepointableActorRef: HasContext = HasTransientContext.fromCurrentContext()
 
   @Pointcut("execution(akka.actor.RepointableActorRef.new(..)) && this(repointableActorRef)")
   def envelopeCreation(repointableActorRef: HasContext): Unit = {}

--- a/kamon-akka-2.4.x/src/main/scala/kamon/akka/context/HasTransientContext.scala
+++ b/kamon-akka-2.4.x/src/main/scala/kamon/akka/context/HasTransientContext.scala
@@ -1,0 +1,25 @@
+package kamon.akka.context
+
+import kamon.Kamon
+import kamon.context.{Context, HasContext}
+
+object HasTransientContext {
+
+  private case class DefaultTransient(@transient context: Context) extends HasContext
+
+  /**
+    * Construct a HasSpan instance that references the provided Context.
+    *
+    */
+  def from(context: Context): HasContext =
+    DefaultTransient(context)
+
+  /**
+    * Construct a HasContext instance with the current Kamon from Kamon's default context storage.
+    *
+    */
+  def fromCurrentContext(): HasContext =
+    DefaultTransient(Kamon.currentContext())
+
+}
+

--- a/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/ActorLoggingInstrumentation.scala
+++ b/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/ActorLoggingInstrumentation.scala
@@ -17,6 +17,7 @@
 package akka.kamon.instrumentation
 
 import kamon.Kamon
+import kamon.akka.context.HasTransientContext
 import kamon.context.HasContext
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation._
@@ -25,7 +26,7 @@ import org.aspectj.lang.annotation._
 class ActorLoggingInstrumentation  {
 
   @DeclareMixin("akka.event.Logging.LogEvent+")
-  def mixinHasContextToLogEvent: HasContext = HasContext.fromCurrentContext()
+  def mixinHasContextToLogEvent: HasContext = HasTransientContext.fromCurrentContext()
 
   @Pointcut("execution(akka.event.Logging.LogEvent+.new(..)) && this(event)")
   def logEventCreation(event: HasContext): Unit = {}

--- a/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/ActorSystemMessageInstrumentation.scala
+++ b/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/ActorSystemMessageInstrumentation.scala
@@ -18,6 +18,7 @@ package akka.kamon.instrumentation
 
 import akka.dispatch.sysmsg.EarliestFirstSystemMessageList
 import kamon.Kamon
+import kamon.akka.context.HasTransientContext
 import kamon.context.HasContext
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation._
@@ -42,7 +43,7 @@ class ActorSystemMessageInstrumentation {
 class HasContextIntoSystemMessageMixin {
 
   @DeclareMixin("akka.dispatch.sysmsg.SystemMessage+")
-  def mixinHasContextToSystemMessage: HasContext = HasContext.fromCurrentContext()
+  def mixinHasContextToSystemMessage: HasContext = HasTransientContext.fromCurrentContext()
 
   @Pointcut("execution(akka.dispatch.sysmsg.SystemMessage+.new(..)) && this(message)")
   def systemMessageCreation(message: HasContext): Unit = {}
@@ -58,7 +59,7 @@ class HasContextIntoSystemMessageMixin {
 class HasContextIntoRepointableActorRefMixin {
 
   @DeclareMixin("akka.actor.RepointableActorRef")
-  def mixinHasContextToRepointableActorRef: HasContext = HasContext.fromCurrentContext()
+  def mixinHasContextToRepointableActorRef: HasContext = HasTransientContext.fromCurrentContext()
 
   @Pointcut("execution(akka.actor.RepointableActorRef.new(..)) && this(repointableActorRef)")
   def envelopeCreation(repointableActorRef: HasContext): Unit = {}

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/context/HasTransientContext.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/context/HasTransientContext.scala
@@ -1,0 +1,25 @@
+package kamon.akka.context
+
+import kamon.Kamon
+import kamon.context.{Context, HasContext}
+
+object HasTransientContext {
+
+  private case class DefaultTransient(@transient context: Context) extends HasContext
+
+  /**
+    * Construct a HasSpan instance that references the provided Context.
+    *
+    */
+  def from(context: Context): HasContext =
+    DefaultTransient(context)
+
+  /**
+    * Construct a HasContext instance with the current Kamon from Kamon's default context storage.
+    *
+    */
+  def fromCurrentContext(): HasContext =
+    DefaultTransient(Kamon.currentContext())
+
+}
+

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/ActorLoggingInstrumentation.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/ActorLoggingInstrumentation.scala
@@ -17,6 +17,7 @@
 package akka.kamon.instrumentation
 
 import kamon.Kamon
+import kamon.akka.context.HasTransientContext
 import kamon.context.HasContext
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation._
@@ -25,7 +26,7 @@ import org.aspectj.lang.annotation._
 class ActorLoggingInstrumentation  {
 
   @DeclareMixin("akka.event.Logging.LogEvent+")
-  def mixinHasContextToLogEvent: HasContext = HasContext.fromCurrentContext()
+  def mixinHasContextToLogEvent: HasContext = HasTransientContext.fromCurrentContext()
 
   @Pointcut("execution(akka.event.Logging.LogEvent+.new(..)) && this(event)")
   def logEventCreation(event: HasContext): Unit = {}

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/ActorSystemMessageInstrumentation.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/ActorSystemMessageInstrumentation.scala
@@ -18,6 +18,7 @@ package akka.kamon.instrumentation
 
 import akka.dispatch.sysmsg.EarliestFirstSystemMessageList
 import kamon.Kamon
+import kamon.akka.context.HasTransientContext
 import kamon.context.HasContext
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation._
@@ -42,7 +43,7 @@ class ActorSystemMessageInstrumentation {
 class HasContextIntoSystemMessageMixin {
 
   @DeclareMixin("akka.dispatch.sysmsg.SystemMessage+")
-  def mixinHasContextToSystemMessage: HasContext = HasContext.fromCurrentContext()
+  def mixinHasContextToSystemMessage: HasContext = HasTransientContext.fromCurrentContext()
 
   @Pointcut("execution(akka.dispatch.sysmsg.SystemMessage+.new(..)) && this(message)")
   def systemMessageCreation(message: HasContext): Unit = {}
@@ -58,7 +59,7 @@ class HasContextIntoSystemMessageMixin {
 class HasContextIntoRepointableActorRefMixin {
 
   @DeclareMixin("akka.actor.RepointableActorRef")
-  def mixinHasContextToRepointableActorRef: HasContext = HasContext.fromCurrentContext()
+  def mixinHasContextToRepointableActorRef: HasContext = HasTransientContext.fromCurrentContext()
 
   @Pointcut("execution(akka.actor.RepointableActorRef.new(..)) && this(repointableActorRef)")
   def envelopeCreation(repointableActorRef: HasContext): Unit = {}

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
-version in ThisBuild := "1.0.0-RC4"
+version in ThisBuild := "1.0.0-RC5-SNAPSHOT"
 


### PR DESCRIPTION
In order not to interfere with non-instrumented systems when remoting, context mixed in with system messages should not cross the system boundary. 

Context propagation in these cases should be handled in `kamon-akka-remote` module.