### PR TITLE
Fix operation name on message processing

### DIFF
--- a/kamon-akka-2.3.x/src/main/scala/kamon/akka/instrumentation/ActorMonitor.scala
+++ b/kamon-akka-2.3.x/src/main/scala/kamon/akka/instrumentation/ActorMonitor.scala
@@ -88,7 +88,9 @@ object ActorMonitors {
 
     private def tagSpan(cellInfo: CellInfo, envelope: Envelope, context: Context) = {
       val span = context.get(Span.ContextKey)
-      val messageClass = envelope.message.getClass.getSimpleName
+      val cls = envelope.message.getClass
+      // could fail, check SI-2034
+      val messageClass = try { cls.getSimpleName } catch { case _ => cls.getName }
 
       span.setOperationName(s"${cellInfo.actorName}.$messageClass")
 

--- a/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/ActorMonitor.scala
+++ b/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/ActorMonitor.scala
@@ -88,7 +88,9 @@ object ActorMonitors {
 
     private def tagSpan(cellInfo: CellInfo, envelope: Envelope, context: Context) = {
       val span = context.get(Span.ContextKey)
-      val messageClass = envelope.message.getClass.getSimpleName
+      val cls = envelope.message.getClass
+      // could fail, check SI-2034
+      val messageClass = try { cls.getSimpleName } catch { case _ => cls.getName }
 
       span.setOperationName(s"${cellInfo.actorName}.$messageClass")
 

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/ActorMonitor.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/ActorMonitor.scala
@@ -88,7 +88,9 @@ object ActorMonitors {
 
     private def tagSpan(cellInfo: CellInfo, envelope: Envelope, context: Context) = {
       val span = context.get(Span.ContextKey)
-      val messageClass = envelope.message.getClass.getSimpleName
+      val cls = envelope.message.getClass
+      // could fail, check SI-2034
+      val messageClass = try { cls.getSimpleName } catch { case _ => cls.getName }
 
       span.setOperationName(s"${cellInfo.actorName}.$messageClass")
 


### PR DESCRIPTION
Use `getName` since `getSimpleName` could explode, related… SI-2034