### PR TITLE
Settable context mixin for SystemMessages

### DIFF
--- a/kamon-akka-2.3.x/src/main/scala/kamon/akka/context/HasTransientContext.scala
+++ b/kamon-akka-2.3.x/src/main/scala/kamon/akka/context/HasTransientContext.scala
@@ -3,23 +3,29 @@ package kamon.akka.context
 import kamon.Kamon
 import kamon.context.{Context, HasContext}
 
+trait ContextContainer extends HasContext {
+  def setContext(context: Context)
+}
+
 object HasTransientContext {
 
-  private case class DefaultTransient(@transient context: Context) extends HasContext
+  private class DefaultTransient(@transient var context: Context) extends ContextContainer with Serializable {
+    override def setContext(context: Context): Unit = this.context = context
+  }
 
   /**
     * Construct a HasSpan instance that references the provided Context.
     *
     */
-  def from(context: Context): HasContext =
-    DefaultTransient(context)
+  def from(context: Context): ContextContainer =
+    new DefaultTransient(context)
 
   /**
     * Construct a HasContext instance with the current Kamon from Kamon's default context storage.
     *
     */
-  def fromCurrentContext(): HasContext =
-    DefaultTransient(Kamon.currentContext())
+  def fromCurrentContext(): ContextContainer =
+    new DefaultTransient(Kamon.currentContext())
 
 }
 

--- a/kamon-akka-2.3.x/src/main/scala/kamon/akka/instrumentation/ActorSystemMessageInstrumentation.scala
+++ b/kamon-akka-2.3.x/src/main/scala/kamon/akka/instrumentation/ActorSystemMessageInstrumentation.scala
@@ -18,7 +18,7 @@ package akka.kamon.instrumentation
 
 import akka.dispatch.sysmsg.EarliestFirstSystemMessageList
 import kamon.Kamon
-import kamon.akka.context.HasTransientContext
+import kamon.akka.context.{ContextContainer, HasTransientContext}
 import kamon.context.HasContext
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation._
@@ -43,13 +43,13 @@ class ActorSystemMessageInstrumentation {
 class HasContextIntoSystemMessageMixin {
 
   @DeclareMixin("akka.dispatch.sysmsg.SystemMessage+")
-  def mixinHasContextToSystemMessage: HasContext = HasTransientContext.fromCurrentContext()
+  def mixinHasContextToSystemMessage: ContextContainer = HasTransientContext.fromCurrentContext()
 
   @Pointcut("execution(akka.dispatch.sysmsg.SystemMessage+.new(..)) && this(message)")
-  def systemMessageCreation(message: HasContext): Unit = {}
+  def systemMessageCreation(message: ContextContainer): Unit = {}
 
   @After("systemMessageCreation(message)")
-  def afterSystemMessageCreation(message: HasContext): Unit = {
+  def afterSystemMessageCreation(message: ContextContainer): Unit = {
     // Necessary to force the initialization of HasContext at the moment of creation.
     message.context
   }

--- a/kamon-akka-2.4.x/src/main/scala/kamon/akka/context/HasTransientContext.scala
+++ b/kamon-akka-2.4.x/src/main/scala/kamon/akka/context/HasTransientContext.scala
@@ -3,23 +3,29 @@ package kamon.akka.context
 import kamon.Kamon
 import kamon.context.{Context, HasContext}
 
+trait ContextContainer extends HasContext {
+  def setContext(context: Context)
+}
+
 object HasTransientContext {
 
-  private case class DefaultTransient(@transient context: Context) extends HasContext
+  private class DefaultTransient(@transient var context: Context) extends ContextContainer with Serializable {
+    override def setContext(context: Context): Unit = this.context = context
+  }
 
   /**
     * Construct a HasSpan instance that references the provided Context.
     *
     */
-  def from(context: Context): HasContext =
-    DefaultTransient(context)
+  def from(context: Context): ContextContainer =
+    new DefaultTransient(context)
 
   /**
     * Construct a HasContext instance with the current Kamon from Kamon's default context storage.
     *
     */
-  def fromCurrentContext(): HasContext =
-    DefaultTransient(Kamon.currentContext())
+  def fromCurrentContext(): ContextContainer =
+    new DefaultTransient(Kamon.currentContext())
 
 }
 

--- a/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/ActorSystemMessageInstrumentation.scala
+++ b/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/ActorSystemMessageInstrumentation.scala
@@ -18,7 +18,7 @@ package akka.kamon.instrumentation
 
 import akka.dispatch.sysmsg.EarliestFirstSystemMessageList
 import kamon.Kamon
-import kamon.akka.context.HasTransientContext
+import kamon.akka.context.{ContextContainer, HasTransientContext}
 import kamon.context.HasContext
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation._
@@ -43,13 +43,13 @@ class ActorSystemMessageInstrumentation {
 class HasContextIntoSystemMessageMixin {
 
   @DeclareMixin("akka.dispatch.sysmsg.SystemMessage+")
-  def mixinHasContextToSystemMessage: HasContext = HasTransientContext.fromCurrentContext()
+  def mixinHasContextToSystemMessage: ContextContainer = HasTransientContext.fromCurrentContext()
 
   @Pointcut("execution(akka.dispatch.sysmsg.SystemMessage+.new(..)) && this(message)")
-  def systemMessageCreation(message: HasContext): Unit = {}
+  def systemMessageCreation(message: ContextContainer): Unit = {}
 
   @After("systemMessageCreation(message)")
-  def afterSystemMessageCreation(message: HasContext): Unit = {
+  def afterSystemMessageCreation(message: ContextContainer): Unit = {
     // Necessary to force the initialization of HasContext at the moment of creation.
     message.context
   }

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/context/HasTransientContext.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/context/HasTransientContext.scala
@@ -3,23 +3,29 @@ package kamon.akka.context
 import kamon.Kamon
 import kamon.context.{Context, HasContext}
 
+trait ContextContainer extends HasContext {
+  def setContext(context: Context)
+}
+
 object HasTransientContext {
 
-  private case class DefaultTransient(@transient context: Context) extends HasContext
+  private class DefaultTransient(@transient var context: Context) extends ContextContainer with Serializable {
+    override def setContext(context: Context): Unit = this.context = context
+  }
 
   /**
     * Construct a HasSpan instance that references the provided Context.
     *
     */
-  def from(context: Context): HasContext =
-    DefaultTransient(context)
+  def from(context: Context): ContextContainer =
+    new DefaultTransient(context)
 
   /**
     * Construct a HasContext instance with the current Kamon from Kamon's default context storage.
     *
     */
-  def fromCurrentContext(): HasContext =
-    DefaultTransient(Kamon.currentContext())
+  def fromCurrentContext(): ContextContainer =
+    new DefaultTransient(Kamon.currentContext())
 
 }
 

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/ActorSystemMessageInstrumentation.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/ActorSystemMessageInstrumentation.scala
@@ -18,7 +18,7 @@ package akka.kamon.instrumentation
 
 import akka.dispatch.sysmsg.EarliestFirstSystemMessageList
 import kamon.Kamon
-import kamon.akka.context.HasTransientContext
+import kamon.akka.context.{ContextContainer, HasTransientContext}
 import kamon.context.HasContext
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation._
@@ -43,13 +43,13 @@ class ActorSystemMessageInstrumentation {
 class HasContextIntoSystemMessageMixin {
 
   @DeclareMixin("akka.dispatch.sysmsg.SystemMessage+")
-  def mixinHasContextToSystemMessage: HasContext = HasTransientContext.fromCurrentContext()
+  def mixinHasContextToSystemMessage: ContextContainer = HasTransientContext.fromCurrentContext()
 
   @Pointcut("execution(akka.dispatch.sysmsg.SystemMessage+.new(..)) && this(message)")
-  def systemMessageCreation(message: HasContext): Unit = {}
+  def systemMessageCreation(message: ContextContainer): Unit = {}
 
   @After("systemMessageCreation(message)")
-  def afterSystemMessageCreation(message: HasContext): Unit = {
+  def afterSystemMessageCreation(message: ContextContainer): Unit = {
     // Necessary to force the initialization of HasContext at the moment of creation.
     message.context
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.0-RC5"
+version in ThisBuild := "1.0.0-RC5-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.0-RC5-SNAPSHOT"
+version in ThisBuild := "1.0.0-RC6-SNAPSHOT"


### PR DESCRIPTION
Mixin with context setter to enable updating `SystemMessage` context after deserialization in remoting (since its transient)