### PR TITLE
Router metric improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ val kamonExecutors  = "io.kamon" %% "kamon-executors"    % "1.0.1"
 
 val `akka-2.3` = "2.3.15"
 val `akka-2.4` = "2.4.20"
-val `akka-2.5` = "2.5.8"
+val `akka-2.5` = "2.5.13"
 
 def akkaDependency(name: String, version: String) = {
   "com.typesafe.akka" %% s"akka-$name" % version

--- a/kamon-akka-2.4.x/src/main/scala/kamon/akka/Metrics.scala
+++ b/kamon-akka-2.4.x/src/main/scala/kamon/akka/Metrics.scala
@@ -70,31 +70,45 @@ object Metrics {
     *      that message is dequeued for processing.
     *    - processing-time: Time taken for the actor to process the receive function.
     *    - errors: Number or errors seen by the actor's supervision mechanism.
+    *    - pending-messages: Number of messages waiting to be processed across all routees.
     */
   val routerRoutingTime = Kamon.histogram("akka.router.routing-time", time.nanoseconds)
   val routerTimeInMailbox = Kamon.histogram("akka.router.time-in-mailbox", time.nanoseconds)
   val routerProcessingTime = Kamon.histogram("akka.router.processing-time", time.nanoseconds)
+  val routerPendingMessages = Kamon.rangeSampler("akka.router.pending-messages")
+  val routerMembers = Kamon.rangeSampler("akka.router.members")
   val routerErrors = Kamon.counter("akka.router.errors")
 
-  def forRouter(path: String, system: String, dispatcher: String, actorClass: String): RouterMetrics = {
-    val routerTags = Map("path" -> path, "system" -> system, "dispatcher" -> dispatcher)
+  def forRouter(path: String, system: String, dispatcher: String, routerClass: String, routeeClass: String): RouterMetrics = {
+    val routerTags = Map(
+      "path" -> path,
+      "system" -> system,
+      "dispatcher" -> dispatcher,
+      "routerClass" -> routerClass,
+      "routeeClass" -> routeeClass
+    )
+
     RouterMetrics(
       routerTags,
       routerRoutingTime.refine(routerTags),
       routerTimeInMailbox.refine(routerTags),
       routerProcessingTime.refine(routerTags),
+      routerPendingMessages.refine(routerTags),
+      routerMembers.refine(routerTags),
       routerErrors.refine(routerTags)
     )
   }
 
   case class RouterMetrics(tags: Map[String, String], routingTime: Histogram, timeInMailbox: Histogram,
-      processingTime: Histogram, errors: Counter) {
+      processingTime: Histogram, pendingMessages: RangeSampler, members: RangeSampler, errors: Counter) {
 
     def cleanup(): Unit = {
       routerRoutingTime.remove(tags)
       routerTimeInMailbox.remove(tags)
       routerProcessingTime.remove(tags)
       routerErrors.remove(tags)
+      routerPendingMessages.remove(tags)
+      routerMembers.remove(tags)
     }
   }
 
@@ -113,7 +127,7 @@ object Metrics {
     */
   val groupTimeInMailbox = Kamon.histogram("akka.group.time-in-mailbox", time.nanoseconds)
   val groupProcessingTime = Kamon.histogram("akka.group.processing-time", time.nanoseconds)
-  val groupMailboxSize = Kamon.rangeSampler("akka.group.mailbox-size")
+  val groupPendingMessages = Kamon.rangeSampler("akka.group.pending-messages")
   val groupMembers = Kamon.rangeSampler("akka.group.members")
   val groupErrors = Kamon.counter("akka.group.errors")
 
@@ -123,19 +137,19 @@ object Metrics {
       actorTags,
       groupTimeInMailbox.refine(actorTags),
       groupProcessingTime.refine(actorTags),
-      groupMailboxSize.refine(actorTags),
+      groupPendingMessages.refine(actorTags),
       groupMembers.refine(actorTags),
       groupErrors.refine(actorTags)
     )
   }
 
   case class ActorGroupMetrics(tags: Map[String, String], timeInMailbox: Histogram, processingTime: Histogram,
-      mailboxSize: RangeSampler, members: RangeSampler, errors: Counter) {
+      pendingMessages: RangeSampler, members: RangeSampler, errors: Counter) {
 
     def cleanup(): Unit = {
       groupTimeInMailbox.remove(tags)
       groupProcessingTime.remove(tags)
-      groupMailboxSize.remove(tags)
+      groupPendingMessages.remove(tags)
       groupMembers.remove(tags)
       groupErrors.remove(tags)
     }

--- a/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/ActorInstrumentation.scala
+++ b/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/ActorInstrumentation.scala
@@ -140,6 +140,14 @@ class ActorCellInstrumentation {
   def beforeInvokeFailure(cell: ActorCell, childrenNotToSuspend: immutable.Iterable[ActorRef], failure: Throwable): Unit = {
     actorInstrumentation(cell).processFailure(failure)
   }
+
+  @Pointcut("execution(* akka.dispatch.MessageDispatcher.unregister(..)) && args(cell)")
+  def messageDispatcherUnregister(cell: ActorCell): Unit = {}
+
+  @Before("messageDispatcherUnregister(cell)")
+  def beforeMessageDispatcherUnregister(cell: ActorCell): Unit = {
+    actorInstrumentation(cell).processDroppedMessage(cell.mailbox.numberOfMessages)
+  }
 }
 
 object ActorCellInstrumentation {

--- a/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/ActorMonitor.scala
+++ b/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/ActorMonitor.scala
@@ -14,6 +14,7 @@ trait ActorMonitor {
   def captureEnvelopeContext(): TimestampedContext
   def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext, envelope: Envelope): AnyRef
   def processFailure(failure: Throwable): Unit
+  def processDroppedMessage(count: Long): Unit
   def cleanup(): Unit
 }
 
@@ -42,7 +43,7 @@ object ActorMonitor {
 
   def createRegularActorMonitor(cellInfo: CellInfo): ActorMonitor = {
     if (cellInfo.isTracked || !cellInfo.trackingGroups.isEmpty) {
-      val actorMetrics = if (cellInfo.isTracked) Some(Metrics.forActor(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName, cellInfo.actorClass.getName)) else None
+      val actorMetrics = if (cellInfo.isTracked) Some(Metrics.forActor(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName, cellInfo.actorOrRouterClass.getName)) else None
       new TrackedActor(actorMetrics, trackingGroupMetrics(cellInfo), cellInfo.actorCellCreation, cellInfo)
     } else {
       ActorMonitors.ContextPropagationOnly(cellInfo)
@@ -50,7 +51,9 @@ object ActorMonitor {
   }
 
   def createRouteeMonitor(cellInfo: CellInfo): ActorMonitor = {
-    val routerMetrics = Metrics.forRouter(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName, cellInfo.actorClass.getName)
+    val routerMetrics = Metrics.forRouter(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName, cellInfo.actorOrRouterClass.getName,
+      cellInfo.routeeClass.map(_.getName).getOrElse("Unknown"))
+
     new TrackedRoutee(routerMetrics, trackingGroupMetrics(cellInfo), cellInfo.actorCellCreation, cellInfo)
   }
 
@@ -66,8 +69,8 @@ object ActorMonitors {
 
 
   class TracedMonitor(cellInfo: CellInfo, monitor: ActorMonitor) extends ActorMonitor {
-    private val actorClassName = cellInfo.actorClass.getName
-    private val actorSimpleClassName = simpleClassName(cellInfo.actorClass)
+    private val actorClassName = cellInfo.actorOrRouterClass.getName
+    private val actorSimpleClassName = simpleClassName(cellInfo.actorOrRouterClass)
 
     override def captureEnvelopeContext(): TimestampedContext = {
       monitor.captureEnvelopeContext()
@@ -85,6 +88,7 @@ object ActorMonitors {
     }
 
     override def processFailure(failure: Throwable): Unit = monitor.processFailure(failure)
+    override def processDroppedMessage(count: Long): Unit = monitor.processDroppedMessage(count)
 
     override def cleanup(): Unit = monitor.cleanup()
 
@@ -125,6 +129,7 @@ object ActorMonitors {
     }
 
     def processFailure(failure: Throwable): Unit = {}
+    def processDroppedMessage(count: Long): Unit = {}
     def cleanup(): Unit = {
       Metrics.forSystem(cellInfo.systemName).activeActors.decrement()
     }
@@ -176,6 +181,10 @@ object ActorMonitors {
       super.processFailure(failure: Throwable)
     }
 
+    override def processDroppedMessage(count: Long): Unit = {
+      // Dropped messages are only measured for routees
+    }
+
     override def cleanup(): Unit = {
       super.cleanup()
       actorMetrics.foreach(_.cleanup())
@@ -185,7 +194,15 @@ object ActorMonitors {
   class TrackedRoutee(routerMetrics: RouterMetrics, groupMetrics: Seq[ActorGroupMetrics], actorCellCreation: Boolean, cellInfo: CellInfo)
       extends GroupMetricsTrackingActor(groupMetrics, actorCellCreation, cellInfo) {
 
+    routerMetrics.members.increment()
     private val processedMessagesCounter = Metrics.forSystem(cellInfo.systemName).processedMessagesByTracked
+
+
+
+    override def captureEnvelopeContext(): TimestampedContext = {
+      routerMetrics.pendingMessages.increment()
+      super.captureEnvelopeContext()
+    }
 
     def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext, envelope: Envelope): AnyRef = {
       val timestampBeforeProcessing = Kamon.clock().nanos()
@@ -202,6 +219,7 @@ object ActorMonitors {
 
         routerMetrics.processingTime.record(processingTime)
         routerMetrics.timeInMailbox.record(timeInMailbox)
+        routerMetrics.pendingMessages.decrement()
         recordProcessMetrics(processingTime, timeInMailbox)
       }
     }
@@ -211,9 +229,14 @@ object ActorMonitors {
       super.processFailure(failure)
     }
 
+
+    override def processDroppedMessage(count: Long): Unit = {
+      routerMetrics.pendingMessages.decrement(count)
+    }
+
     override def cleanup(): Unit = {
       super.cleanup()
-      routerMetrics.cleanup()
+      routerMetrics.members.decrement()
     }
   }
 
@@ -226,7 +249,7 @@ object ActorMonitors {
 
     def captureEnvelopeContext(): TimestampedContext = {
       groupMetrics.foreach { gm =>
-        gm.mailboxSize.increment()
+        gm.pendingMessages.increment()
       }
 
       TimestampedContext(Kamon.clock().nanos(), Kamon.currentContext())
@@ -242,7 +265,7 @@ object ActorMonitors {
       groupMetrics.foreach { gm =>
         gm.processingTime.record(processingTime)
         gm.timeInMailbox.record(timeInMailbox)
-        gm.mailboxSize.decrement()
+        gm.pendingMessages.decrement()
       }
     }
 

--- a/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/CellInfo.scala
+++ b/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/CellInfo.scala
@@ -15,13 +15,15 @@
 package akka.kamon.instrumentation
 
 import akka.actor.{ActorRef, ActorSystem, Cell}
-import akka.routing.{NoRouter, RoutedActorRef}
+import akka.routing.{BalancingPool, NoRouter, RoutedActorCell, RoutedActorRef}
 import kamon.Kamon
 import kamon.akka.Akka
+
 import scala.language.existentials
 
 case class CellInfo(path: String, isRouter: Boolean, isRoutee: Boolean, isTracked: Boolean, trackingGroups: Seq[String],
-    actorCellCreation: Boolean, systemName: String, dispatcherName: String, isTraced: Boolean, actorClass: Class[_], actorName: String)
+    actorCellCreation: Boolean, systemName: String, dispatcherName: String, isTraced: Boolean, actorOrRouterClass: Class[_],
+    routeeClass: Option[Class[_]], actorName: String)
 
 object CellInfo {
 
@@ -31,7 +33,6 @@ object CellInfo {
   def cellInfoFor(cell: Cell, system: ActorSystem, ref: ActorRef, parent: ActorRef, actorCellCreation: Boolean): CellInfo = {
     def hasRouterProps(cell: Cell): Boolean = cell.props.deploy.routerConfig != NoRouter
 
-    val actorClass = cell.props.actorClass()
     val actorName = ref.path.name
 
     val pathString = ref.path.elements.mkString("/")
@@ -39,12 +40,29 @@ object CellInfo {
     val isRouter = hasRouterProps(cell)
     val isRoutee = parent.isInstanceOf[RoutedActorRef]
 
+    val (actorOrRouterClass, routeeClass) =
+      if(isRouter)
+        (cell.props.routerConfig.getClass, Some(ref.asInstanceOf[RoutedActorRefAccessor].routeeProps.clazz))
+      else if (isRoutee)
+        (parent.asInstanceOf[RoutedActorRefAccessor].routerProps.routerConfig.getClass, Some(cell.props.clazz))
+      else
+        (cell.props.clazz, None)
+
     val fullPath = if (isRoutee) cellName(system, parent) else cellName(system, ref)
     val filterName = if (isRouter || isRoutee) Akka.RouterFilterName else Akka.ActorFilterName
     val isTracked = !isRootSupervisor && Kamon.filter(filterName, fullPath)
     val isTraced = Kamon.filter(Akka.ActorTracingFilterName, fullPath)
     val trackingGroups = if(isRootSupervisor) List() else Akka.actorGroups.filter(group => Kamon.filter(group, fullPath))
 
-    CellInfo(fullPath, isRouter, isRoutee, isTracked, trackingGroups, actorCellCreation, system.name, cell.props.dispatcher, isTraced, actorClass, actorName)
+    val dispatcherName = if(isRouter && cell.props.routerConfig.isInstanceOf[BalancingPool]) {
+      // Even though the router actor for a BalancingPool can have a different dispatcher we will
+      // assign the name of the same dispatcher where the routees will run to ensure all metrics are
+      // correlated and cleaned up correctly.
+      val deployPath = ref.path.elements.drop(1).mkString("/", "/", "")
+      "BalancingPool-" + deployPath
+    } else cell.props.dispatcher
+
+    CellInfo(fullPath, isRouter, isRoutee, isTracked, trackingGroups, actorCellCreation, system.name, dispatcherName,
+      isTraced, actorOrRouterClass, routeeClass, actorName)
   }
 }

--- a/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/RouterMonitor.scala
+++ b/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/RouterMonitor.scala
@@ -21,7 +21,15 @@ object RouterMonitor {
     val cellInfo = CellInfo.cellInfoFor(cell, cell.system, cell.self, cell.parent, false)
 
     if (cellInfo.isTracked)
-      new MetricsOnlyRouterMonitor(Metrics.forRouter(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName, cellInfo.actorClass.getName))
+      new MetricsOnlyRouterMonitor(
+        Metrics.forRouter(
+          cellInfo.path,
+          cellInfo.systemName,
+          cellInfo.dispatcherName,
+          cellInfo.actorOrRouterClass.getName,
+          cellInfo.routeeClass.map(_.getName).getOrElse("Unknown")
+        )
+      )
     else NoOpRouterMonitor
   }
 }
@@ -52,5 +60,7 @@ class MetricsOnlyRouterMonitor(routerMetrics: RouterMetrics) extends RouterMonit
   def processFailure(failure: Throwable): Unit = {}
   def routeeAdded(): Unit = {}
   def routeeRemoved(): Unit = {}
-  def cleanup(): Unit = routerMetrics.cleanup()
+  def cleanup(): Unit = {
+    routerMetrics.cleanup()
+  }
 }

--- a/kamon-akka-2.4.x/src/test/resources/application.conf
+++ b/kamon-akka-2.4.x/src/test/resources/application.conf
@@ -30,7 +30,7 @@ kamon {
       }
 
       "akka.tracked-router" {
-        includes = [ "*/user/tracked-*", "*/user/measuring-*", "*/user/stop-*" ]
+        includes = [ "*/user/tracked-*", "*/user/measuring-*", "*/user/cleanup-*", "*/user/stop-*" ]
         excludes = [ "*/user/tracked-explicitly-excluded-*"]
       }
 

--- a/kamon-akka-2.4.x/src/test/scala/kamon/akka/RouterMetricsSpec.scala
+++ b/kamon-akka-2.4.x/src/test/scala/kamon/akka/RouterMetricsSpec.scala
@@ -120,6 +120,111 @@ class RouterMetricsSpec extends TestKit(ActorSystem("RouterMetricsSpec")) with W
       timeInMailboxDistribution.buckets.head.value should be(timings.approximateTimeInMailbox +- 10.millis.toNanos)
     }
 
+
+    "record pending-messages for pool routers" in new RouterMetricsFixtures {
+      val timingsListener = TestProbe()
+      val router = createTestPoolRouter("measuring-pending-messages-in-pool-router", true)
+      def pendingMessagesDistribution = routerPendingMessages
+        .refine(routerTags("RouterMetricsSpec/user/measuring-pending-messages-in-pool-router")).distribution()
+
+      10 times { router.tell(RouterTrackTimings(sleep = Some(1 second)), timingsListener.ref)}
+      10 times { timingsListener.expectMsgType[RouterTrackedTimings] }
+
+      pendingMessagesDistribution.max should be >= (5L)
+
+      eventually {
+        pendingMessagesDistribution.max should be (0L)
+      }
+    }
+
+    "record pending-messages for balancing pool routers" in new RouterMetricsFixtures {
+      val timingsListener = TestProbe()
+      val router = createTestBalancingPoolRouter("measuring-pending-messages-in-balancing-pool-router", true)
+      def pendingMessagesDistribution = routerPendingMessages
+        .refine(routerTags("RouterMetricsSpec/user/measuring-pending-messages-in-balancing-pool-router") ++
+          Map("dispatcher" -> "BalancingPool-/measuring-pending-messages-in-balancing-pool-router")).distribution()
+
+      10 times { router.tell(RouterTrackTimings(sleep = Some(1 second)), timingsListener.ref)}
+      10 times { timingsListener.expectMsgType[RouterTrackedTimings] }
+
+      pendingMessagesDistribution.max should be >= (5L)
+
+      eventually {
+        pendingMessagesDistribution.max should be (0L)
+      }
+    }
+
+    "record member count for pool routers" in new RouterMetricsFixtures {
+      val timingsListener = TestProbe()
+      val router = createTestPoolRouter("measuring-members-in-pool-router", true)
+      def membersDistribution = routerMembers
+        .refine(routerTags("RouterMetricsSpec/user/measuring-members-in-pool-router")).distribution()
+
+      for(routeesLeft <- 4 to 0 by -1) {
+        100 times { router.tell(Discard, timingsListener.ref) }
+        router.tell(Die, timingsListener.ref)
+
+        eventually {
+          membersDistribution.max should be (routeesLeft)
+        }
+      }
+    }
+
+    "record member count for balancing pool routers" in new RouterMetricsFixtures {
+      val timingsListener = TestProbe()
+      val router = createTestBalancingPoolRouter("measuring-members-in-balancing-pool-router", true)
+      def membersDistribution = routerMembers
+        .refine(routerTags("RouterMetricsSpec/user/measuring-members-in-balancing-pool-router") ++
+          Map("dispatcher" -> "BalancingPool-/measuring-members-in-balancing-pool-router")).distribution()
+
+      for(routeesLeft <- 4 to 0 by -1) {
+        100 times { router.tell(Discard, timingsListener.ref) }
+        router.tell(Die, timingsListener.ref)
+
+        eventually {
+          membersDistribution.max should be (routeesLeft)
+        }
+      }
+    }
+
+
+    "clean the pending messages metric when a routee dies in pool routers" in new RouterMetricsFixtures {
+      val timingsListener = TestProbe()
+      val router = createTestPoolRouter("cleanup-pending-messages-in-pool-router", true)
+      def pendingMessagesDistribution = routerPendingMessages
+        .refine(routerTags("RouterMetricsSpec/user/cleanup-pending-messages-in-pool-router")).distribution()
+
+      10 times { router.tell(RouterTrackTimings(sleep = Some(1 second)), timingsListener.ref)}
+      1 times { router.tell(Die, timingsListener.ref)}
+      500 times { router.tell(Discard, timingsListener.ref)}
+
+      pendingMessagesDistribution.max should be >= (500L)
+      10 times { timingsListener.expectMsgType[RouterTrackedTimings] }
+
+      eventually {
+        pendingMessagesDistribution.max should be (0L)
+      }
+    }
+
+    "clean the pending messages metric when a routee dies in balancing pool routers" in new RouterMetricsFixtures {
+      val timingsListener = TestProbe()
+      val router = createTestBalancingPoolRouter("cleanup-pending-messages-in-balancing-pool-router", true)
+      def pendingMessagesDistribution = routerPendingMessages
+        .refine(routerTags("RouterMetricsSpec/user/cleanup-pending-messages-in-balancing-pool-router") ++
+          Map("dispatcher" -> "BalancingPool-/cleanup-pending-messages-in-balancing-pool-router")).distribution()
+
+      10 times { router.tell(RouterTrackTimings(sleep = Some(1 second)), timingsListener.ref)}
+      1 times { router.tell(Die, timingsListener.ref)}
+      500 times { router.tell(Discard, timingsListener.ref)}
+
+      pendingMessagesDistribution.max should be >= (100L)
+      10 times { timingsListener.expectMsgType[RouterTrackedTimings] }
+
+      eventually {
+        pendingMessagesDistribution.max should be (0L)
+      }
+    }
+
     "clean up the associated recorder when the pool router is stopped" in new RouterMetricsFixtures {
       val trackedRouter = createTestPoolRouter("stop-in-pool-router")
       routerProcessingTime.valuesForTag("path") should contain("RouterMetricsSpec/user/stop-in-pool-router")
@@ -138,11 +243,17 @@ class RouterMetricsSpec extends TestKit(ActorSystem("RouterMetricsSpec")) with W
 
   override protected def afterAll(): Unit = shutdown()
 
-  def routerTags(path: String): Map[String, String] = Map(
-    "path" -> path,
-    "system" -> "RouterMetricsSpec",
-    "dispatcher" -> "akka.actor.default-dispatcher"
-  )
+  def routerTags(path: String): Map[String, String] = {
+    val routerClass = if(path.contains("balancing")) "akka.routing.BalancingPool" else "akka.routing.RoundRobinPool"
+
+    Map(
+      "path" -> path,
+      "system" -> "RouterMetricsSpec",
+      "dispatcher" -> "akka.actor.default-dispatcher",
+      "routeeClass" -> "kamon.akka.RouterMetricsTestActor",
+      "routerClass" -> routerClass
+    )
+  }
 
 
   trait RouterMetricsFixtures {
@@ -183,8 +294,9 @@ class RouterMetricsSpec extends TestKit(ActorSystem("RouterMetricsSpec")) with W
         routerTimeInMailbox.refine(routerTags(s"RouterMetricsSpec/user/$routerName")).distribution(resetState = true)
         routerProcessingTime.refine(routerTags(s"RouterMetricsSpec/user/$routerName")).distribution(resetState = true)
         routerErrors.refine(routerTags(s"RouterMetricsSpec/user/$routerName")).value(resetState = true)
+        routerPendingMessages.refine(routerTags(s"RouterMetricsSpec/user/$routerName")).distribution(resetState = true)
+        routerMembers.refine(routerTags(s"RouterMetricsSpec/user/$routerName")).distribution(resetState = true)
       }
-
 
       router
     }
@@ -200,14 +312,15 @@ class RouterMetricsSpec extends TestKit(ActorSystem("RouterMetricsSpec")) with W
       // Cleanup all the metric recording instruments:
       if(resetState) {
         val tags = routerTags(s"RouterMetricsSpec/user/$routerName") ++
-          Map("dispatcher" -> "BalancingPool-/measuring-time-in-mailbox-in-balancing-pool-router")
+          Map("dispatcher" -> s"BalancingPool-/$routerName")
 
         routerRoutingTime.refine(tags).distribution(resetState = true)
         routerTimeInMailbox.refine(tags).distribution(resetState = true)
         routerProcessingTime.refine(tags).distribution(resetState = true)
+        routerPendingMessages.refine(tags).distribution(resetState = true)
+        routerMembers.refine(tags).distribution(resetState = true)
         routerErrors.refine(tags).value(resetState = true)
       }
-
 
       router
     }

--- a/kamon-akka-2.4.x/src/test/scala/kamon/akka/RouterMetricsTestActor.scala
+++ b/kamon-akka-2.4.x/src/test/scala/kamon/akka/RouterMetricsTestActor.scala
@@ -25,6 +25,7 @@ class RouterMetricsTestActor extends Actor {
   import RouterMetricsTestActor._
   override def receive = {
     case Discard ⇒
+    case Die     ⇒ context.stop(self)
     case Fail    ⇒ throw new ArithmeticException("Division by zero.")
     case Ping    ⇒ sender ! Pong
     case RouterTrackTimings(sendTimestamp, sleep) ⇒ {
@@ -42,6 +43,7 @@ object RouterMetricsTestActor {
   case object Pong
   case object Fail
   case object Discard
+  case object Die
 
   case class RouterTrackTimings(sendTimestamp: Long = Kamon.clock().nanos(), sleep: Option[Duration] = None)
   case class RouterTrackedTimings(sendTimestamp: Long, dequeueTimestamp: Long, afterReceiveTimestamp: Long) {

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/Metrics.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/Metrics.scala
@@ -79,8 +79,15 @@ object Metrics {
   val routerMembers = Kamon.rangeSampler("akka.router.members")
   val routerErrors = Kamon.counter("akka.router.errors")
 
-  def forRouter(path: String, system: String, dispatcher: String, actorClass: String): RouterMetrics = {
-    val routerTags = Map("path" -> path, "system" -> system, "dispatcher" -> dispatcher)
+  def forRouter(path: String, system: String, dispatcher: String, routerClass: String, routeeClass: String): RouterMetrics = {
+    val routerTags = Map(
+      "path" -> path,
+      "system" -> system,
+      "dispatcher" -> dispatcher,
+      "routerClass" -> routerClass,
+      "routeeClass" -> routeeClass
+    )
+
     RouterMetrics(
       routerTags,
       routerRoutingTime.refine(routerTags),

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/Metrics.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/Metrics.scala
@@ -127,7 +127,7 @@ object Metrics {
     */
   val groupTimeInMailbox = Kamon.histogram("akka.group.time-in-mailbox", time.nanoseconds)
   val groupProcessingTime = Kamon.histogram("akka.group.processing-time", time.nanoseconds)
-  val groupMailboxSize = Kamon.rangeSampler("akka.group.mailbox-size")
+  val groupPendingMessages = Kamon.rangeSampler("akka.group.pending-messages")
   val groupMembers = Kamon.rangeSampler("akka.group.members")
   val groupErrors = Kamon.counter("akka.group.errors")
 
@@ -137,19 +137,19 @@ object Metrics {
       actorTags,
       groupTimeInMailbox.refine(actorTags),
       groupProcessingTime.refine(actorTags),
-      groupMailboxSize.refine(actorTags),
+      groupPendingMessages.refine(actorTags),
       groupMembers.refine(actorTags),
       groupErrors.refine(actorTags)
     )
   }
 
   case class ActorGroupMetrics(tags: Map[String, String], timeInMailbox: Histogram, processingTime: Histogram,
-      mailboxSize: RangeSampler, members: RangeSampler, errors: Counter) {
+      pendingMessages: RangeSampler, members: RangeSampler, errors: Counter) {
 
     def cleanup(): Unit = {
       groupTimeInMailbox.remove(tags)
       groupProcessingTime.remove(tags)
-      groupMailboxSize.remove(tags)
+      groupPendingMessages.remove(tags)
       groupMembers.remove(tags)
       groupErrors.remove(tags)
     }

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/ActorInstrumentation.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/ActorInstrumentation.scala
@@ -140,6 +140,14 @@ class ActorCellInstrumentation {
   def beforeInvokeFailure(cell: ActorCell, childrenNotToSuspend: immutable.Iterable[ActorRef], failure: Throwable): Unit = {
     actorInstrumentation(cell).processFailure(failure)
   }
+
+  @Pointcut("execution(* akka.dispatch.MessageDispatcher.unregister(..)) && args(cell)")
+  def messageDispatcherUnregister(cell: ActorCell): Unit = {}
+
+  @Before("messageDispatcherUnregister(cell)")
+  def beforeMessageDispatcherUnregister(cell: ActorCell): Unit = {
+    actorInstrumentation(cell).processDroppedMessage(cell.mailbox.numberOfMessages)
+  }
 }
 
 object ActorCellInstrumentation {

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/ActorMonitor.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/ActorMonitor.scala
@@ -43,7 +43,7 @@ object ActorMonitor {
 
   def createRegularActorMonitor(cellInfo: CellInfo): ActorMonitor = {
     if (cellInfo.isTracked || !cellInfo.trackingGroups.isEmpty) {
-      val actorMetrics = if (cellInfo.isTracked) Some(Metrics.forActor(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName, cellInfo.actorClass.getName)) else None
+      val actorMetrics = if (cellInfo.isTracked) Some(Metrics.forActor(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName, cellInfo.actorOrRouterClass.getName)) else None
       new TrackedActor(actorMetrics, trackingGroupMetrics(cellInfo), cellInfo.actorCellCreation, cellInfo)
     } else {
       ActorMonitors.ContextPropagationOnly(cellInfo)
@@ -51,7 +51,9 @@ object ActorMonitor {
   }
 
   def createRouteeMonitor(cellInfo: CellInfo): ActorMonitor = {
-    val routerMetrics = Metrics.forRouter(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName, cellInfo.actorClass.getName)
+    val routerMetrics = Metrics.forRouter(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName, cellInfo.actorOrRouterClass.getName,
+      cellInfo.routeeClass.map(_.getName).getOrElse("Unknown"))
+
     new TrackedRoutee(routerMetrics, trackingGroupMetrics(cellInfo), cellInfo.actorCellCreation, cellInfo)
   }
 
@@ -67,8 +69,8 @@ object ActorMonitors {
 
 
   class TracedMonitor(cellInfo: CellInfo, monitor: ActorMonitor) extends ActorMonitor {
-    private val actorClassName = cellInfo.actorClass.getName
-    private val actorSimpleClassName = simpleClassName(cellInfo.actorClass)
+    private val actorClassName = cellInfo.actorOrRouterClass.getName
+    private val actorSimpleClassName = simpleClassName(cellInfo.actorOrRouterClass)
 
     override def captureEnvelopeContext(): TimestampedContext = {
       monitor.captureEnvelopeContext()
@@ -151,7 +153,6 @@ object ActorMonitors {
     }
 
     def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext, envelope: Envelope): AnyRef = {
-      println("=====> Processing Message: " + envelope.message)
       val timestampBeforeProcessing = Kamon.clock().nanos()
       processedMessagesCounter.increment()
 
@@ -204,7 +205,6 @@ object ActorMonitors {
     }
 
     def processMessage(pjp: ProceedingJoinPoint, envelopeContext: TimestampedContext, envelope: Envelope): AnyRef = {
-      println("=====> Processing Message Routee: " + envelope.message)
       val timestampBeforeProcessing = Kamon.clock().nanos()
       processedMessagesCounter.increment()
 

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/ActorMonitor.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/ActorMonitor.scala
@@ -249,7 +249,7 @@ object ActorMonitors {
 
     def captureEnvelopeContext(): TimestampedContext = {
       groupMetrics.foreach { gm =>
-        gm.mailboxSize.increment()
+        gm.pendingMessages.increment()
       }
 
       TimestampedContext(Kamon.clock().nanos(), Kamon.currentContext())
@@ -265,7 +265,7 @@ object ActorMonitors {
       groupMetrics.foreach { gm =>
         gm.processingTime.record(processingTime)
         gm.timeInMailbox.record(timeInMailbox)
-        gm.mailboxSize.decrement()
+        gm.pendingMessages.decrement()
       }
     }
 

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/CellInfo.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/CellInfo.scala
@@ -15,13 +15,15 @@
 package akka.kamon.instrumentation
 
 import akka.actor.{ActorRef, ActorSystem, Cell}
-import akka.routing.{NoRouter, RoutedActorRef}
+import akka.routing.{BalancingPool, NoRouter, RoutedActorCell, RoutedActorRef}
 import kamon.Kamon
 import kamon.akka.Akka
+
 import scala.language.existentials
 
 case class CellInfo(path: String, isRouter: Boolean, isRoutee: Boolean, isTracked: Boolean, trackingGroups: Seq[String],
-    actorCellCreation: Boolean, systemName: String, dispatcherName: String, isTraced: Boolean, actorClass: Class[_], actorName: String)
+    actorCellCreation: Boolean, systemName: String, dispatcherName: String, isTraced: Boolean, actorOrRouterClass: Class[_],
+    routeeClass: Option[Class[_]], actorName: String)
 
 object CellInfo {
 
@@ -31,7 +33,6 @@ object CellInfo {
   def cellInfoFor(cell: Cell, system: ActorSystem, ref: ActorRef, parent: ActorRef, actorCellCreation: Boolean): CellInfo = {
     def hasRouterProps(cell: Cell): Boolean = cell.props.deploy.routerConfig != NoRouter
 
-    val actorClass = cell.props.actorClass()
     val actorName = ref.path.name
 
     val pathString = ref.path.elements.mkString("/")
@@ -39,12 +40,29 @@ object CellInfo {
     val isRouter = hasRouterProps(cell)
     val isRoutee = parent.isInstanceOf[RoutedActorRef]
 
+    val (actorOrRouterClass, routeeClass) =
+      if(isRouter)
+        (cell.props.routerConfig.getClass, Some(ref.asInstanceOf[RoutedActorRefAccessor].routeeProps.clazz))
+      else if (isRoutee)
+        (parent.asInstanceOf[RoutedActorRefAccessor].routerProps.routerConfig.getClass, Some(cell.props.clazz))
+      else
+        (cell.props.clazz, None)
+
     val fullPath = if (isRoutee) cellName(system, parent) else cellName(system, ref)
     val filterName = if (isRouter || isRoutee) Akka.RouterFilterName else Akka.ActorFilterName
     val isTracked = !isRootSupervisor && Kamon.filter(filterName, fullPath)
     val isTraced = Kamon.filter(Akka.ActorTracingFilterName, fullPath)
     val trackingGroups = if(isRootSupervisor) List() else Akka.actorGroups.filter(group => Kamon.filter(group, fullPath))
 
-    CellInfo(fullPath, isRouter, isRoutee, isTracked, trackingGroups, actorCellCreation, system.name, cell.props.dispatcher, isTraced, actorClass, actorName)
+    val dispatcherName = if(isRouter && cell.props.routerConfig.isInstanceOf[BalancingPool]) {
+      // Even though the router actor for a BalancingPool can have a different dispatcher we will
+      // assign the name of the same dispatcher where the routees will run to ensure all metrics are
+      // correlated and cleaned up correctly.
+      val deployPath = ref.path.elements.drop(1).mkString("/", "/", "")
+      "BalancingPool-" + deployPath
+    } else cell.props.dispatcher
+
+    CellInfo(fullPath, isRouter, isRoutee, isTracked, trackingGroups, actorCellCreation, system.name, dispatcherName,
+      isTraced, actorOrRouterClass, routeeClass, actorName)
   }
 }

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/RouterMonitor.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/RouterMonitor.scala
@@ -52,5 +52,7 @@ class MetricsOnlyRouterMonitor(routerMetrics: RouterMetrics) extends RouterMonit
   def processFailure(failure: Throwable): Unit = {}
   def routeeAdded(): Unit = {}
   def routeeRemoved(): Unit = {}
-  def cleanup(): Unit = routerMetrics.cleanup()
+  def cleanup(): Unit = {
+    routerMetrics.cleanup()
+  }
 }

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/RouterMonitor.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/RouterMonitor.scala
@@ -21,7 +21,15 @@ object RouterMonitor {
     val cellInfo = CellInfo.cellInfoFor(cell, cell.system, cell.self, cell.parent, false)
 
     if (cellInfo.isTracked)
-      new MetricsOnlyRouterMonitor(Metrics.forRouter(cellInfo.path, cellInfo.systemName, cellInfo.dispatcherName, cellInfo.actorClass.getName))
+      new MetricsOnlyRouterMonitor(
+        Metrics.forRouter(
+          cellInfo.path,
+          cellInfo.systemName,
+          cellInfo.dispatcherName,
+          cellInfo.actorOrRouterClass.getName,
+          cellInfo.routeeClass.map(_.getName).getOrElse("Unknown")
+        )
+      )
     else NoOpRouterMonitor
   }
 }

--- a/kamon-akka-2.5.x/src/test/resources/application.conf
+++ b/kamon-akka-2.5.x/src/test/resources/application.conf
@@ -32,7 +32,7 @@ kamon {
       }
 
       "akka.tracked-router" {
-        includes = [ "*/user/tracked-*", "*/user/measuring-*", "*/user/stop-*" ]
+        includes = [ "*/user/tracked-*", "*/user/measuring-*", "*/user/cleanup-*", "*/user/stop-*" ]
         excludes = [ "*/user/tracked-explicitly-excluded-*"]
       }
 

--- a/kamon-akka-2.5.x/src/test/scala/kamon/akka/RouterMetricsSpec.scala
+++ b/kamon-akka-2.5.x/src/test/scala/kamon/akka/RouterMetricsSpec.scala
@@ -120,6 +120,111 @@ class RouterMetricsSpec extends TestKit(ActorSystem("RouterMetricsSpec")) with W
       timeInMailboxDistribution.buckets.head.value should be(timings.approximateTimeInMailbox +- 10.millis.toNanos)
     }
 
+
+    "record pending-messages for pool routers" in new RouterMetricsFixtures {
+      val timingsListener = TestProbe()
+      val router = createTestPoolRouter("measuring-pending-messages-in-pool-router", true)
+      def pendingMessagesDistribution = routerPendingMessages
+        .refine(routerTags("RouterMetricsSpec/user/measuring-pending-messages-in-pool-router")).distribution()
+
+      10 times { router.tell(RouterTrackTimings(sleep = Some(1 second)), timingsListener.ref)}
+      10 times { timingsListener.expectMsgType[RouterTrackedTimings] }
+
+      pendingMessagesDistribution.max should be >= (5L)
+
+      eventually {
+        pendingMessagesDistribution.max should be (0L)
+      }
+    }
+
+    "record pending-messages for balancing pool routers" in new RouterMetricsFixtures {
+      val timingsListener = TestProbe()
+      val router = createTestBalancingPoolRouter("measuring-pending-messages-in-balancing-pool-router", true)
+      def pendingMessagesDistribution = routerPendingMessages
+        .refine(routerTags("RouterMetricsSpec/user/measuring-pending-messages-in-balancing-pool-router") ++
+          Map("dispatcher" -> "BalancingPool-/measuring-pending-messages-in-balancing-pool-router")).distribution()
+
+      10 times { router.tell(RouterTrackTimings(sleep = Some(1 second)), timingsListener.ref)}
+      10 times { timingsListener.expectMsgType[RouterTrackedTimings] }
+
+      pendingMessagesDistribution.max should be >= (5L)
+
+      eventually {
+        pendingMessagesDistribution.max should be (0L)
+      }
+    }
+
+    "record member count for pool routers" in new RouterMetricsFixtures {
+      val timingsListener = TestProbe()
+      val router = createTestPoolRouter("measuring-members-in-pool-router", true)
+      def membersDistribution = routerMembers
+        .refine(routerTags("RouterMetricsSpec/user/measuring-members-in-pool-router")).distribution()
+
+      for(routeesLeft <- 4 to 0 by -1) {
+        100 times { router.tell(Discard, timingsListener.ref) }
+        router.tell(Die, timingsListener.ref)
+
+        eventually {
+          membersDistribution.max should be (routeesLeft)
+        }
+      }
+    }
+
+    "record member count for balancing pool routers" in new RouterMetricsFixtures {
+      val timingsListener = TestProbe()
+      val router = createTestBalancingPoolRouter("measuring-members-in-balancing-pool-router", true)
+      def membersDistribution = routerMembers
+        .refine(routerTags("RouterMetricsSpec/user/measuring-members-in-balancing-pool-router") ++
+          Map("dispatcher" -> "BalancingPool-/measuring-members-in-balancing-pool-router")).distribution()
+
+      for(routeesLeft <- 4 to 0 by -1) {
+        100 times { router.tell(Discard, timingsListener.ref) }
+        router.tell(Die, timingsListener.ref)
+
+        eventually {
+          membersDistribution.max should be (routeesLeft)
+        }
+      }
+    }
+
+
+    "clean the pending messages metric when a routee dies in pool routers" in new RouterMetricsFixtures {
+      val timingsListener = TestProbe()
+      val router = createTestPoolRouter("cleanup-pending-messages-in-pool-router", true)
+      def pendingMessagesDistribution = routerPendingMessages
+        .refine(routerTags("RouterMetricsSpec/user/cleanup-pending-messages-in-pool-router")).distribution()
+
+      10 times { router.tell(RouterTrackTimings(sleep = Some(1 second)), timingsListener.ref)}
+      1 times { router.tell(Die, timingsListener.ref)}
+      500 times { router.tell(Discard, timingsListener.ref)}
+
+      pendingMessagesDistribution.max should be >= (500L)
+      10 times { timingsListener.expectMsgType[RouterTrackedTimings] }
+
+      eventually {
+        pendingMessagesDistribution.max should be (0L)
+      }
+    }
+
+    "clean the pending messages metric when a routee dies in balancing pool routers" in new RouterMetricsFixtures {
+      val timingsListener = TestProbe()
+      val router = createTestBalancingPoolRouter("cleanup-pending-messages-in-balancing-pool-router", true)
+      def pendingMessagesDistribution = routerPendingMessages
+        .refine(routerTags("RouterMetricsSpec/user/cleanup-pending-messages-in-balancing-pool-router") ++
+          Map("dispatcher" -> "BalancingPool-/cleanup-pending-messages-in-balancing-pool-router")).distribution()
+
+      10 times { router.tell(RouterTrackTimings(sleep = Some(1 second)), timingsListener.ref)}
+      1 times { router.tell(Die, timingsListener.ref)}
+      500 times { router.tell(Discard, timingsListener.ref)}
+
+      pendingMessagesDistribution.max should be >= (100L)
+      10 times { timingsListener.expectMsgType[RouterTrackedTimings] }
+
+      eventually {
+        pendingMessagesDistribution.max should be (0L)
+      }
+    }
+
     "clean up the associated recorder when the pool router is stopped" in new RouterMetricsFixtures {
       val trackedRouter = createTestPoolRouter("stop-in-pool-router")
       routerProcessingTime.valuesForTag("path") should contain("RouterMetricsSpec/user/stop-in-pool-router")
@@ -183,6 +288,8 @@ class RouterMetricsSpec extends TestKit(ActorSystem("RouterMetricsSpec")) with W
         routerTimeInMailbox.refine(routerTags(s"RouterMetricsSpec/user/$routerName")).distribution(resetState = true)
         routerProcessingTime.refine(routerTags(s"RouterMetricsSpec/user/$routerName")).distribution(resetState = true)
         routerErrors.refine(routerTags(s"RouterMetricsSpec/user/$routerName")).value(resetState = true)
+        routerPendingMessages.refine(routerTags(s"RouterMetricsSpec/user/$routerName")).distribution(resetState = true)
+        routerMembers.refine(routerTags(s"RouterMetricsSpec/user/$routerName")).distribution(resetState = true)
       }
 
 
@@ -205,6 +312,8 @@ class RouterMetricsSpec extends TestKit(ActorSystem("RouterMetricsSpec")) with W
         routerRoutingTime.refine(tags).distribution(resetState = true)
         routerTimeInMailbox.refine(tags).distribution(resetState = true)
         routerProcessingTime.refine(tags).distribution(resetState = true)
+        routerPendingMessages.refine(tags).distribution(resetState = true)
+        routerMembers.refine(tags).distribution(resetState = true)
         routerErrors.refine(tags).value(resetState = true)
       }
 

--- a/kamon-akka-2.5.x/src/test/scala/kamon/akka/RouterMetricsTestActor.scala
+++ b/kamon-akka-2.5.x/src/test/scala/kamon/akka/RouterMetricsTestActor.scala
@@ -25,6 +25,7 @@ class RouterMetricsTestActor extends Actor {
   import RouterMetricsTestActor._
   override def receive = {
     case Discard ⇒
+    case Die     ⇒ context.stop(self)
     case Fail    ⇒ throw new ArithmeticException("Division by zero.")
     case Ping    ⇒ sender ! Pong
     case RouterTrackTimings(sendTimestamp, sleep) ⇒ {
@@ -42,6 +43,7 @@ object RouterMetricsTestActor {
   case object Pong
   case object Fail
   case object Discard
+  case object Die
 
   case class RouterTrackTimings(sendTimestamp: Long = Kamon.clock().nanos(), sleep: Option[Duration] = None)
   case class RouterTrackedTimings(sendTimestamp: Long, dequeueTimestamp: Long, afterReceiveTimestamp: Long) {


### PR DESCRIPTION
The PR includes a few changes:
  - Introduced two new metrics:
    - `akka.router.pending-messages` as a range sampler tracking how many messages are waiting to be processed across all routees of a router.
    - `akka.router.members` as a range sampler tracking the number of routees in a router.
  - The `akka.group.mailbox-size` metric was renamed to `akka.group.pending-messages` to stay consistent with the previous change (pending messages is much more close to reality than mailbox size since there is no single mailbox there).
  - All routers now have a `routerClass` and `routeeClass` tags.
  - The `dispatcher` tag used on BalancingPool routers have been fixed. For this type of routers the routees would always get a special dispatcher assigned, but the router itself could run on a different dispatcher (usually the default dispatcher). This duplicates the number of metrics created for BalancingDispatchers and leaves half of them alive when removing the router. Since this PR the router actor will have the disparcher tag value to match the dispatcher name of the routees, which is not accurate, but we can live with that.

These changes are only applied for Akka 2.5 for review, if all looks good I'll migrate them to Akka 2.4 as well.