### PR TITLE
pick the right dispatcher name when deployment configuration overrides routees dispatchers

### DIFF
--- a/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/CellInfo.scala
+++ b/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/CellInfo.scala
@@ -14,7 +14,7 @@
  */
 package akka.kamon.instrumentation
 
-import akka.actor.{ActorRef, ActorSystem, Cell}
+import akka.actor.{ActorRef, ActorSystem, Cell, Deployer, ExtendedActorSystem}
 import akka.routing.{BalancingPool, NoRouter, RoutedActorCell, RoutedActorRef}
 import kamon.Kamon
 import kamon.akka.Akka
@@ -54,12 +54,21 @@ object CellInfo {
     val isTraced = Kamon.filter(Akka.ActorTracingFilterName, fullPath)
     val trackingGroups = if(isRootSupervisor) List() else Akka.actorGroups.filter(group => Kamon.filter(group, fullPath))
 
-    val dispatcherName = if(isRouter && cell.props.routerConfig.isInstanceOf[BalancingPool]) {
-      // Even though the router actor for a BalancingPool can have a different dispatcher we will
-      // assign the name of the same dispatcher where the routees will run to ensure all metrics are
-      // correlated and cleaned up correctly.
-      val deployPath = ref.path.elements.drop(1).mkString("/", "/", "")
-      "BalancingPool-" + deployPath
+    val dispatcherName = if(isRouter) {
+      if(cell.props.routerConfig.isInstanceOf[BalancingPool]) {
+        // Even though the router actor for a BalancingPool can have a different dispatcher we will
+        // assign the name of the same dispatcher where the routees will run to ensure all metrics are
+        // correlated and cleaned up correctly.
+        val deployPath = ref.path.elements.drop(1).mkString("/", "/", "")
+        "BalancingPool-" + deployPath
+
+      } else {
+        // It might happen that the deployment configuration will provide a different dispatcher name
+        // for the routees and we should catch that case only when creating the router (the routees will
+        // be initialized with an updated Props instance.
+        val deployer = new Deployer(system.settings, system.asInstanceOf[ExtendedActorSystem].dynamicAccess)
+        deployer.lookup(ref.path / "$a").map(_.dispatcher).getOrElse(cell.props.dispatcher)
+      }
     } else cell.props.dispatcher
 
     CellInfo(fullPath, isRouter, isRoutee, isTracked, trackingGroups, actorCellCreation, system.name, dispatcherName,

--- a/kamon-akka-2.4.x/src/test/resources/application.conf
+++ b/kamon-akka-2.4.x/src/test/resources/application.conf
@@ -1,7 +1,31 @@
 akka {
-  loglevel = DEBUG
+  loglevel = INFO
   loggers = [ "akka.event.slf4j.Slf4jLogger" ]
   logger-startup-timeout = 30s
+
+  actor {
+    serialize-messages=on
+
+    deployment {
+      /picking-the-right-dispatcher-in-pool-router {
+        router = round-robin-pool
+        resizer = {
+          lower-bound = 5
+          upper-bound = 64
+          messages-per-resize = 20
+        }
+      }
+
+      "/picking-the-right-dispatcher-in-pool-router/*" {
+        dispatcher = custom-dispatcher
+      }
+    }
+  }
+}
+
+custom-dispatcher {
+  executor = "thread-pool-executor"
+  type = PinnedDispatcher
 }
 
 kamon {
@@ -30,7 +54,7 @@ kamon {
       }
 
       "akka.tracked-router" {
-        includes = [ "*/user/tracked-*", "*/user/measuring-*", "*/user/cleanup-*", "*/user/stop-*" ]
+        includes = [ "*/user/tracked-*", "*/user/measuring-*", "*/user/cleanup-*", "*/user/picking-*", "*/user/stop-*" ]
         excludes = [ "*/user/tracked-explicitly-excluded-*"]
       }
 
@@ -73,9 +97,6 @@ explicitly-excluded {
   type = "Dispatcher"
   executor = "fork-join-executor"
 }
-
-
-akka.actor.default-dispatcher.shutdown-timeout = 30s
 
 tracked-fjp {
   type = "Dispatcher"

--- a/kamon-akka-2.4.x/src/test/scala/kamon/akka/RouterMetricsSpec.scala
+++ b/kamon-akka-2.4.x/src/test/scala/kamon/akka/RouterMetricsSpec.scala
@@ -187,6 +187,18 @@ class RouterMetricsSpec extends TestKit(ActorSystem("RouterMetricsSpec")) with W
       }
     }
 
+    "pick the right dispatcher name when the routees have a custom dispatcher set via deployment configuration" in new RouterMetricsFixtures {
+      val testProbe = TestProbe()
+      val router = system.actorOf(FromConfig.props(Props[RouterMetricsTestActor]), "picking-the-right-dispatcher-in-pool-router")
+
+      10 times {
+        router.tell(Ping, testProbe.ref)
+        testProbe.expectMsg(Pong)
+      }
+
+      val routerMetrics = routerMembers.partialRefine(Map("path" -> "RouterMetricsSpec/user/picking-the-right-dispatcher-in-pool-router"))
+      routerMetrics.map(m => m("dispatcher")) should contain only("custom-dispatcher")
+    }
 
     "clean the pending messages metric when a routee dies in pool routers" in new RouterMetricsFixtures {
       val timingsListener = TestProbe()

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/CellInfo.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/CellInfo.scala
@@ -14,7 +14,7 @@
  */
 package akka.kamon.instrumentation
 
-import akka.actor.{ActorRef, ActorSystem, Cell}
+import akka.actor.{ActorRef, ActorSystem, Cell, Deployer, ExtendedActorSystem}
 import akka.routing.{BalancingPool, NoRouter, RoutedActorCell, RoutedActorRef}
 import kamon.Kamon
 import kamon.akka.Akka
@@ -54,12 +54,21 @@ object CellInfo {
     val isTraced = Kamon.filter(Akka.ActorTracingFilterName, fullPath)
     val trackingGroups = if(isRootSupervisor) List() else Akka.actorGroups.filter(group => Kamon.filter(group, fullPath))
 
-    val dispatcherName = if(isRouter && cell.props.routerConfig.isInstanceOf[BalancingPool]) {
-      // Even though the router actor for a BalancingPool can have a different dispatcher we will
-      // assign the name of the same dispatcher where the routees will run to ensure all metrics are
-      // correlated and cleaned up correctly.
-      val deployPath = ref.path.elements.drop(1).mkString("/", "/", "")
-      "BalancingPool-" + deployPath
+    val dispatcherName = if(isRouter) {
+      if(cell.props.routerConfig.isInstanceOf[BalancingPool]) {
+        // Even though the router actor for a BalancingPool can have a different dispatcher we will
+        // assign the name of the same dispatcher where the routees will run to ensure all metrics are
+        // correlated and cleaned up correctly.
+        val deployPath = ref.path.elements.drop(1).mkString("/", "/", "")
+        "BalancingPool-" + deployPath
+
+      } else {
+        // It might happen that the deployment configuration will provide a different dispatcher name
+        // for the routees and we should catch that case only when creating the router (the routees will
+        // be initialized with an updated Props instance.
+        val deployer = new Deployer(system.settings, system.asInstanceOf[ExtendedActorSystem].dynamicAccess)
+        deployer.lookup(ref.path / "$a").map(_.dispatcher).getOrElse(cell.props.dispatcher)
+      }
     } else cell.props.dispatcher
 
     CellInfo(fullPath, isRouter, isRoutee, isTracked, trackingGroups, actorCellCreation, system.name, dispatcherName,

--- a/kamon-akka-2.5.x/src/test/resources/application.conf
+++ b/kamon-akka-2.5.x/src/test/resources/application.conf
@@ -3,7 +3,29 @@ akka {
   loggers = [ "akka.event.slf4j.Slf4jLogger" ]
   logger-startup-timeout = 30s
 
-  actor.serialize-messages=on
+  actor {
+    serialize-messages=on
+
+    deployment {
+      /picking-the-right-dispatcher-in-pool-router {
+        router = round-robin-pool
+        resizer = {
+          lower-bound = 5
+          upper-bound = 64
+          messages-per-resize = 20
+        }
+      }
+
+      "/picking-the-right-dispatcher-in-pool-router/*" {
+        dispatcher = custom-dispatcher
+      }
+    }
+  }
+}
+
+custom-dispatcher {
+  executor = "thread-pool-executor"
+  type = PinnedDispatcher
 }
 
 kamon {
@@ -32,7 +54,7 @@ kamon {
       }
 
       "akka.tracked-router" {
-        includes = [ "*/user/tracked-*", "*/user/measuring-*", "*/user/cleanup-*", "*/user/stop-*" ]
+        includes = [ "*/user/tracked-*", "*/user/measuring-*", "*/user/cleanup-*", "*/user/picking-*", "*/user/stop-*" ]
         excludes = [ "*/user/tracked-explicitly-excluded-*"]
       }
 


### PR DESCRIPTION
There was a small bug in the selection of the dispatcher name when tracking routers/routees: if there was a deployment configuration (under `akka.actor.deployment` for the routees as this one here:

```
akka {
  actor {
    deployment {
      /picking-the-right-dispatcher-in-pool-router {
        router = round-robin-pool
        resizer = {
          lower-bound = 5
          upper-bound = 64
          messages-per-resize = 20
        }
      }

      "/picking-the-right-dispatcher-in-pool-router/*" {
        dispatcher = custom-dispatcher
      }
    }
  }
}

custom-dispatcher {
  executor = "thread-pool-executor"
  type = PinnedDispatcher
}
```

Then at the time the router is created the dispatcher name would be the `akka.actor.default-dispatcher` but when the routees were created the dispatcher would be properly set to `custom-dispatcher`. This was causing two different sets of metrics being created for each router. With these changes the instrumentation will try to resolve any deployment configuration for the routees when instrumenting the router and use that dispatcher instead of the default one.

#### Known limitations:
If someone gets fancy about separating the routees' dispatchers with mode complicated deployment configurations (e.g. having one dispatcher for `router/$a` and another for `router/$b`) the bug might kick again, although that seems like a rather uncommon situation.