### PR TITLE
Streams instrumentation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+
 /* =========================================================================================
  * Copyright © 2013-2016 the kamon project <http://kamon.io/>
  *
@@ -58,6 +59,7 @@ lazy val kamonAkka25 = Project("kamon-akka-25", file("kamon-akka-2.5.x"))
   .settings(
     libraryDependencies ++=
       compileScope(akkaDependency("actor", `akka-2.5`), kamonCore, kamonScala, kamonExecutors) ++
+      compileScope(akkaDependency("stream", `akka-2.5`), kamonCore, kamonScala, kamonExecutors) ++
       providedScope(aspectJ) ++
       optionalScope(logbackClassic) ++
       testScope(scalatest, kamonTestkit, akkaDependency("testkit", `akka-2.5`), akkaDependency("slf4j", `akka-2.5`), logbackClassic))

--- a/kamon-akka-2.5.x/src/main/resources/META-INF/aop.xml
+++ b/kamon-akka-2.5.x/src/main/resources/META-INF/aop.xml
@@ -14,6 +14,15 @@
     <aspect name="akka.kamon.instrumentation.RoutedActorCellInstrumentation"/>
     <aspect name="akka.kamon.instrumentation.ActorLoggingInstrumentation"/>
 
+    <!-- Streams -->
+    <aspect name="akka.stream.instrumentation.StageInterpretationInstrumentation"/>
+    <aspect name="akka.stream.instrumentation.BoundaryInstrumentation"/>
+    <aspect name="akka.stream.instrumentation.AsyncCallbackInstrumentation"/>
+    <aspect name="akka.stream.instrumentation.BufferingStagesInstrumentation"/>
+    <aspect name="akka.stream.instrumentation.StreamOfStreamsInstrumentation"/>
+    <aspect name="akka.stream.instrumentation.SourceInstrumentation"/>
+
+
     <aspect name="akka.kamon.instrumentation.DeadLettersInstrumentation"/>
 
     <!-- Dispatchers -->

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/StreamInstrumentation.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/StreamInstrumentation.scala
@@ -1,0 +1,365 @@
+package akka.stream.instrumentation
+
+import java.util.concurrent.atomic.AtomicReference
+
+import akka.Done
+import akka.stream._
+import akka.stream.impl.Buffer
+import akka.stream.impl.fusing.GraphInterpreter
+import akka.stream.impl.fusing.GraphInterpreter.Connection
+import akka.stream.stage.{GraphStage, GraphStageLogic}
+import kamon.Kamon
+import kamon.context.Context
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation._
+
+import scala.concurrent.Promise
+import scala.util.Try
+
+import scala.collection.JavaConverters._
+
+trait ContextHolder {
+  def setContext(context: Context): Unit
+  def getContext: Context
+}
+
+object ContextHolder {
+  def apply: ContextHolder = new ContextHolder {
+    var context: Context = _
+    var scope: Context = _
+
+    override def setContext(context: Context): Unit = this.context = context
+
+    override def getContext: Context = context
+  }
+}
+
+object InstrumentedBuffer {
+  //TODO pass in materializer
+  //For buffering in custom stages
+  def apply[T](inner: Buffer[T]): InstrumentedBuffer[T] = new InstrumentedBuffer(Buffer[T](10, 1000))
+}
+class InstrumentedBuffer[T](inner: Buffer[T]) extends Buffer[T] {
+  //TODO pass on buffer params from creation point
+  private val contextBuffer = Buffer[Context](10, 100)
+
+  override def capacity: Int = inner.capacity
+
+  override def used: Int = inner.used
+
+  override def isFull: Boolean = inner.isFull
+
+  override def isEmpty: Boolean = inner.isEmpty
+
+  override def nonEmpty: Boolean = inner.nonEmpty
+
+  override def enqueue(elem: T): Unit = {
+    inner.enqueue(elem)
+    contextBuffer.enqueue(Kamon.currentContext())
+  }
+
+  override def dequeue(): T = {
+    val elem = inner.dequeue()
+    Kamon.storeContext(contextBuffer.dequeue())
+    elem
+  }
+
+  override def peek(): T = inner.peek()
+
+  override def clear(): Unit = {
+    contextBuffer.clear()
+    inner.clear()
+  }
+
+  override def dropHead(): Unit = {
+    contextBuffer.dropHead()
+    inner.dropHead()
+  }
+
+  override def dropTail(): Unit = {
+    contextBuffer.dropTail()
+    inner.dropTail()
+  }
+}
+
+@Aspect
+class StageInterpretationInstrumentation {
+
+  @DeclareMixin("akka.stream.impl.fusing.GraphInterpreter.Connection")
+  def mixinInstrumentationIntoConnection: ContextHolder = ContextHolder.apply
+
+  @After("execution(akka.stream.impl.fusing.GraphInterpreter.Connection.new(..)) && this(connection)")
+  def aroundConnectionConstructor(connection: Connection): Unit = {
+    connection.asInstanceOf[ContextHolder].setContext(Context.Empty)
+  }
+
+  @DeclareMixin("akka.stream.stage.GraphStage+")
+  def mixinInstrumentationIntoSourceShapedStages: ContextHolder = ContextHolder.apply
+  //where shape is instanceOf SourceShape
+
+  @After("execution(akka.stream.stage.GraphStage+.new(..)) && this(stage)")
+  def aroundConnectionConstructor(stage: GraphStage[_]): Unit = {
+    stage.asInstanceOf[ContextHolder].setContext(Kamon.currentContext())
+  }
+
+
+
+  @Around("execution(* akka.stream.stage.GraphStageLogic+.grab(..)) && this(logic) && args(inlet)")
+  def aroundGrab(pjp: ProceedingJoinPoint, inlet: Inlet[_], logic: GraphStageLogic): Any = {
+    val connection = connectionForPort(logic, inlet.asInstanceOf[InPort].id)
+
+    Kamon.storeContext(connection.asInstanceOf[ContextHolder].getContext)
+    pjp.proceed()
+  }
+
+  @Around("execution(* akka.stream.stage.GraphStageLogic+.push(..)) && this(logic) && args(outlet, elem)")
+  def aroundPush(pjp: ProceedingJoinPoint, outlet: Outlet[_], elem: Any, logic: GraphStageLogic): Any = {
+    val connection = connectionForPort(logic, outlet.asInstanceOf[OutPort].id + logic.inCount)
+
+    //TODO cache this
+
+    val sourceStageCtx = Try {
+      val graphStageField= logic.getClass.getDeclaredField("$outer")
+      graphStageField.setAccessible(true)
+      val stage = graphStageField.get(logic)
+      val shapeField = stage.getClass.getDeclaredField("shape")
+      shapeField.setAccessible(true)
+      val shape = shapeField.get(stage)
+      if(shape.isInstanceOf[SourceShape[_]]) {
+        stage.asInstanceOf[ContextHolder].getContext
+      } else {
+        Kamon.currentContext()
+      }
+    }
+
+    //If its a source, theres no connection context, use one comming from stage, captured during stage construction
+    val propagatedCtx = sourceStageCtx.getOrElse(Kamon.currentContext())
+
+    connection.asInstanceOf[ContextHolder].setContext(propagatedCtx)
+    pjp.proceed()
+  }
+
+
+  private def connectionForPort(logic: GraphStageLogic, portId: Int): Connection = {
+    val connectionMapping = logic.getClass.getMethod("portToConn")
+    val connections = connectionMapping.invoke(logic).asInstanceOf[Array[Connection]]
+    connections(portId)
+  }
+}
+
+/*
+* SubstreamSource element is created with first element present which is always pulled,
+* all others are synchronous with push, preserving context using AsyncCallback instrumentation
+* */
+@Aspect
+class StreamOfStreamsInstrumentation {
+
+  @DeclareMixin("akka.stream.stage.GraphStageLogic.SubSourceOutlet+")
+  def mixinInstrumentationIntoSubstreamSource: ContextHolder = ContextHolder.apply
+
+  @After("execution(akka.stream.stage.GraphStageLogic.SubSourceOutlet+.new(..)) && this(ssource)")
+  def afterSourceOutletConstructor(ssource: Any): Unit = {
+    ssource.asInstanceOf[ContextHolder].setContext(Kamon.currentContext())
+  }
+
+  @Around("execution(* akka.stream.stage.GraphStageLogic.SubSourceOutlet+.onPull(..)) && this(ssource)")
+  def aroundOnNextExecute(pjp: ProceedingJoinPoint, ssource: Any): Any = {
+    val firstElemContext = ssource.asInstanceOf[ContextHolder].getContext
+    //TODO cache method
+    val firstPush = ssource.getClass.getMethod("firstPush").invoke(ssource).asInstanceOf[Boolean]
+    if (firstPush) Kamon.withContext(firstElemContext) {
+      pjp.proceed()
+    } else {
+      pjp.proceed()
+    }
+  }
+
+  @DeclareMixin("akka.stream.stage.GraphStageLogic.SubSinkInlet+")
+  def mixinInstrumentationIntoSubstreamSink: ContextHolder = ContextHolder.apply
+
+  @After("execution(akka.stream.stage.GraphStageLogic.SubSinkInlet+.new(..)) && this(ssink)")
+  def afterSinkInletConstructor(ssink: Any): Unit = {
+    ssink.asInstanceOf[ContextHolder].setContext(Kamon.currentContext())
+  }
+
+  @Around("execution(* akka.stream.stage.GraphStageLogic.SubSinkInlet+.grab(..)) && this(ssink)")
+  def aroundSinkInletGrab(pjp: ProceedingJoinPoint, ssink: Any): Any = {
+    val sinkCreationPointContext = ssink.asInstanceOf[ContextHolder].getContext
+    Kamon.storeContext(sinkCreationPointContext)
+    pjp.proceed()
+  }
+}
+
+@Aspect
+class BoundaryInstrumentation {
+  @DeclareMixin("akka.stream.impl.fusing.ActorGraphInterpreter.BatchingActorInputBoundary.OnNext")
+  def mixinInstrumentationToOnNext: ContextHolder = ContextHolder.apply
+
+  @After("execution(akka.stream.impl.fusing.ActorGraphInterpreter.BatchingActorInputBoundary.OnNext.new(..)) && this(msg)")
+  def aroundOnNextConstructor(msg: AnyRef): Unit = {
+    msg.asInstanceOf[ContextHolder].setContext(Kamon.currentContext())
+  }
+
+  @Around("execution(* akka.stream.impl.fusing.ActorGraphInterpreter.BatchingActorInputBoundary.OnNext.execute(..)) && this(msg)")
+  def aroundOnNextExecute(pjp: ProceedingJoinPoint, msg: AnyRef): Any = {
+    val ctx = msg.asInstanceOf[ContextHolder].getContext
+    Kamon.withContext(ctx) {
+      pjp.proceed()
+    }
+  }
+
+  @DeclareMixin("akka.stream.impl.fusing.ActorGraphInterpreter.BatchingActorInputBoundary")
+  def mixinInstrumentationIntoBatchingBoundary: ContextHolder = ContextHolder.apply
+
+}
+
+@Aspect
+class BufferingStagesInstrumentation {
+
+  @Around("execution(* akka.stream.stage.GraphStageLogic+.preStart(..)) && this(logic)")
+  def aroundStagePreStart(pjp: ProceedingJoinPoint, logic: GraphStageLogic): Any = {
+    val ret = pjp.proceed()
+    Try(logic.getClass.getDeclaredField("buffer")) foreach { bufferField =>
+      bufferField.setAccessible(true)
+      val innerBuffer = bufferField.get(logic).asInstanceOf[Buffer[Any]]
+      val wrappedBuffer = new InstrumentedBuffer[Any](innerBuffer)
+      bufferField.set(logic, wrappedBuffer)
+    }
+    ret
+  }
+}
+
+
+@Aspect
+class AsyncCallbackInstrumentation {
+
+  @Around("execution(* akka.stream.stage.GraphStageLogic.ConcurrentAsyncCallback.onAsyncInput(..)) && this(callback) && args(event, promise)")
+  def aroundAsyncInvocation(pjp: ProceedingJoinPoint, callback: Any, event: Any, promise: Promise[Done]): Unit = {
+    val stageField = callback.getClass.getDeclaredField("$outer")
+    stageField.setAccessible(true)
+    val stage = stageField.get(callback)
+    val interpreter = stage.getClass
+      .getMethod("interpreter").invoke(stage)
+      .asInstanceOf[GraphInterpreter]
+
+    val handlerField = callback.getClass.getDeclaredField("handler")
+    handlerField.setAccessible(true)
+    val handler: Any => Unit = handlerField.get(callback).asInstanceOf[Any => Unit]
+
+    val contextAwareHandler = {
+      val invocationPointContext = Kamon.currentContext()
+      evt: Any => Kamon.withContext(invocationPointContext) {
+        handler(evt)
+      }
+    }
+
+    interpreter.onAsyncInput(stage.asInstanceOf[GraphStageLogic], event, promise, contextAwareHandler)
+  }
+
+  //TODO instrument callback event wrappers, if stream is not materialized before offering, context is lost on first events
+  @DeclareMixin("akka.stream.stage.GraphStageLogic.ConcurrentAsyncCallback.Event")
+  def mixinInstrumentationIntoCallbackEvent: ContextHolder = ContextHolder.apply
+
+  @After("execution(akka.stream.stage.GraphStageLogic.ConcurrentAsyncCallback.Event.new(..)) && this(event)")
+  def afterEventConstructor(event: Any): Unit = {
+    event.asInstanceOf[ContextHolder].setContext(Kamon.currentContext())
+  }
+
+  private def getPrivateField(name: String, obj: Any): Any = {
+    val field = obj.getClass.getDeclaredField(name)
+    field.setAccessible(true)
+    field.get(obj)
+  }
+
+  /*
+  * Replaces original ConcurrentAsyncCallback.onStart in order to preserve context when
+  * submitting events before Callback started.
+  * If there are pending events, `onAsyncInput` is invoked with context from that event
+  * captured on event creation.
+  * */
+  //TODO nasty reflection here
+  @Around("execution(* akka.stream.stage.GraphStageLogic.ConcurrentAsyncCallback.onStart(..)) && this(callback)")
+  def replaceCallbackOnStart(callback: AnyRef): Unit = {
+    val currentState = getPrivateField("currentState", callback).asInstanceOf[AtomicReference[Any]]
+    //This one could also be potentially uninitialized
+    val NoPendingEvents = getPrivateField("NoPendingEvents", callback)
+    val PendingClass = callback.getClass.getDeclaredField("Pending$module").getType
+    val Initialized = {
+      //force lazy init
+      val method = callback.getClass.getDeclaredMethod("Initialized$lzycompute$1")
+      method.setAccessible(true)
+      method.invoke(callback)
+      getPrivateField("Initialized$module", callback)
+    }
+
+    val onAsyncInputMethod = {
+      val method = {
+        val p1: Class[_] = new Object().getClass
+        val p2: Class[_] = scala.concurrent.Promise[Any].getClass.getInterfaces.head.getInterfaces.head
+        callback.getClass.getDeclaredMethod("onAsyncInput", p1, p2)
+      }
+
+      method.setAccessible(true)
+      method
+    }
+
+    val previousState = currentState.getAndSet(NoPendingEvents)
+
+    val onAsyncInput = (event: AnyRef, promise: Promise[_]) => {
+      onAsyncInputMethod.invoke(callback, event, promise)
+    }
+
+    val pendingEvents = getPrivateField("pendingEvents", previousState)
+
+    //TODO ARGH!!@!#!@, fix inner Pending class nesting :/
+    //if(previousState.getClass == PendingClass) {
+    if(PendingClass.getName.contains(previousState.getClass.getName)) {
+      pendingEvents.asInstanceOf[List[_]].reverse.foreach { event =>
+        val e = getPrivateField("e", event).asInstanceOf[AnyRef]
+        val promise = getPrivateField("handlingPromise", event).asInstanceOf[Promise[_]]
+        val eventCreationPointContext = event.asInstanceOf[ContextHolder].getContext
+        Kamon.withContext(eventCreationPointContext) {
+          onAsyncInput(e, promise)
+        }
+      }
+    } else {
+      throw new IllegalStateException(s"Unexpected callback state [$previousState]")
+    }
+
+    // in the meantime more callbacks might have been queued (we keep queueing them to ensure order)
+    if (!currentState.compareAndSet(NoPendingEvents, Initialized)) {
+      // state guaranteed to be still Pending
+      val onStartMethod = callback.getClass.getDeclaredMethod("onStart")
+      onStartMethod.setAccessible(true)
+      onStartMethod.invoke(callback)
+    }
+  }
+
+}
+
+@Aspect
+class SourceInstrumentation {
+  /*
+  * - single
+  * - fromGraph
+  * - fromFutureSource
+  * - fromFuture
+  * - unfold ???
+  *
+  * Source graph stages GraphStage[SourceShape]
+  *  - SingleSource
+  *  - FutureSource
+  *
+  *  - FutureFlattenSource ???
+  *
+  *
+  *   SingleSource
+      UnfoldResourceSourceAsync  - async
+      FutureSource  - async but if ctx present, callback instrumentation will carry it, wraps push around emit
+      SubSource     - pass, stream of streams
+      JavaStreamSource  - simple
+      UnfoldResourceSource - callback might carry it
+      FailedSource   - skip
+      RestartWithBackoffSource  - ??? no handlers, i guess safe to skip
+  * */
+}

--- a/kamon-akka-2.5.x/src/test/resources/application.conf
+++ b/kamon-akka-2.5.x/src/test/resources/application.conf
@@ -1,5 +1,5 @@
 akka {
-  loglevel = INFO
+  loglevel = DEBUG
   loggers = [ "akka.event.slf4j.Slf4jLogger" ]
   logger-startup-timeout = 30s
 

--- a/kamon-akka-2.5.x/src/test/scala/kamon/akka/StreamSpec.scala
+++ b/kamon-akka-2.5.x/src/test/scala/kamon/akka/StreamSpec.scala
@@ -1,0 +1,305 @@
+package kamon.akka
+
+import akka.NotUsed
+import akka.actor.{ActorSystem, Status}
+import akka.stream.{ActorMaterializer, FlowShape, OverflowStrategy}
+import akka.stream.scaladsl.{Broadcast, Flow, GraphDSL, Keep, Merge, Sink, Source}
+import akka.testkit.{ImplicitSender, TestKit}
+import kamon.Kamon
+import kamon.context.{Context, Key}
+import kamon.context.Storage.Scope
+import kamon.testkit.MetricInspection
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+import org.scalatest.time.{Millis, Seconds, Span}
+
+class StreamSpec extends TestKit(ActorSystem("ActorMetricsSpec")) with WordSpecLike with MetricInspection with Matchers
+  with BeforeAndAfterAll with ImplicitSender with Eventually with ScalaFutures {
+
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(2, Seconds)), interval = scaled(Span(50, Millis)))
+
+  val TraceId: Key[Option[String]] = Key.broadcastString("TraceId")
+
+  def inContext[T](traceId: String)(fn: => T): T = Kamon.withContextKey(TraceId, Some(traceId))(fn)
+  def currentTraceId(): Option[String] = Kamon.currentContext().get(TraceId)
+  def setTraceId(id: String): Scope = Kamon.storeContext(Kamon.currentContext().withKey(TraceId, Some(id)))
+
+  implicit lazy val materializer: ActorMaterializer = ActorMaterializer()
+  implicit val ec: ExecutionContext =  scala.concurrent.ExecutionContext.global
+
+  def currThread = s"${Thread.currentThread().getId}"
+  def setCtx(i: Int): Int = {
+    setTraceId(i.toString)
+    i
+  }
+
+
+  "Stream instrumentation" should {
+
+    "pure source" in {
+      Kamon.withContext(Context.Empty) {
+        setTraceId("outter")
+        val res = Source
+          .fromFuture(Future(3))
+          .map(_ => currentTraceId())
+          .toMat(Sink.seq)(Keep.right)
+          .run()
+
+        res.futureValue.head === "outter"
+      }
+    }
+
+    "group by" in {
+      val nums = Seq(1,2,3,1,2,3,1,2,3,1,2,3)
+      val result = Source.fromIterator(() => nums.toIterator)
+        .map(setCtx)
+        .groupBy(Int.MaxValue, identity)
+        .map(i => {
+          currentTraceId() should be (Some(i.toString))
+          i
+        })
+        .mergeSubstreamsWithParallelism(3)
+        .map(i => {
+          currentTraceId() should be (Some(i.toString))
+          currentTraceId()
+        })
+        .toMat(Sink.seq)(Keep.right)
+        .run()
+
+      result.futureValue should have size nums.size
+      result.futureValue.distinct.flatten should contain allElementsOf nums.distinct.map(_.toString)
+    }
+
+    "flatMap" should {
+      "merge" in {
+        val result = Source(List(10, 20, 30, 40))
+          .map(setCtx)
+          .flatMapMerge(2, i => {
+            currentTraceId() should be (Some(i.toString))
+            Source(List(i+1, i+2))
+          })
+          .map(i => {
+            val sourceTrace = (i / 10) * 10
+            currentTraceId() should be (Some(sourceTrace.toString))
+            i
+          })
+          .toMat(Sink.seq)(Keep.right)
+          .run()
+
+        result.futureValue should have size 8
+      }
+
+      "override substream source context" in {
+        val result = Source(List(10, 20, 30, 40))
+          .map(setCtx)
+          .flatMapMerge(2, i => {
+            currentTraceId() should be (Some(i.toString))
+            Source(List(i+1, i+2))
+          })
+          .map(i => {
+            val sourceTrace = (i / 10) * 10
+            currentTraceId() should be (Some(sourceTrace.toString))
+            setTraceId(i.toString)
+            i
+          }).map(i => {
+            currentTraceId() should be (Some(i.toString))
+          })
+          .toMat(Sink.seq)(Keep.right)
+          .run()
+
+        result.futureValue should have size 8
+      }
+
+      "concat" in { //same as merge with breadth 1
+        val result = Source(List(10, 20, 30, 40))
+          .map(setCtx)
+          .flatMapConcat(i => {
+            currentTraceId() should be (Some(i.toString))
+            Source(List(i+1, i+2))
+          })
+          .map(i => {
+            val sourceTrace = (i / 10) * 10
+            currentTraceId() should be (Some(sourceTrace.toString))
+            i
+          })
+          .toMat(Sink.seq)(Keep.right)
+          .run()
+
+        result.futureValue should have size 8
+      }
+    }
+
+    "mapconcat" in {
+      inContext("init") {
+        val result = Source(1 to 5)
+          .map(setCtx)
+          .mapConcat(i => i*1000 until i*1000+10)
+          .map(i => {
+            val sourceElem = i / 1000
+            currentTraceId() should be (Some(sourceElem.toString))
+            i
+          })
+          .runWith(Sink.seq)
+        result.futureValue should have size 5 * 10
+      }
+    }
+
+    "map" in {
+      inContext("init") {
+        val nums = 1.until(5)
+        val result = Source(nums)
+          .map(setCtx)
+          .map { n =>
+            val trid = currentTraceId()
+            trid should be (Some(n.toString))
+            trid
+          }.runWith(Sink.seq)
+
+        result.futureValue.flatten should have size 4
+        result.futureValue.flatten should contain allElementsOf nums.map(_.toString)
+        currentTraceId() should be (Some("init"))
+      }
+    }
+
+    "map async" should {
+
+      "construction point ctx" in {
+        inContext("init") {
+          val res = Source(1 to 10)
+            .async
+            .map(_ => currentTraceId() )
+            .runWith(Sink.seq)
+            .futureValue
+            .flatten
+
+          res should have size 10
+          res.distinct should contain only "init"
+        }
+      }
+
+      "stage constructed ctx" in {
+        inContext("init") {
+          val nums = List(1,2,3,4,5)
+          val res = Source(nums)
+            .map(setCtx)
+            .async
+            .map(_ => currentTraceId())
+            .runWith(Sink.seq)
+            .futureValue
+            .flatten
+
+          res should have size 5
+          res should contain allElementsOf nums.map(_.toString)
+        }
+      }
+    }
+
+    "Async boundary after buffering" in {
+      //buffer elements with backpressure, then do async, context is lost
+      inContext("outer") {
+        val nums = 1.until(100)
+        val res = Source(nums)
+          .map(setCtx)
+          .async
+          .buffer(10, OverflowStrategy.dropHead)
+          .map { n =>
+            currentTraceId() should be (Some(n.toString))
+            currentTraceId()
+          }.runWith(Sink.seq)
+
+        res.futureValue.flatten should have size nums.size
+        currentTraceId() should be (Some("outer"))
+      }
+    }
+
+    "no backpressure source with buffering " in {
+      inContext("outer") {
+        val (ref, sink) = Source.actorRef[String](100, OverflowStrategy.dropNew)
+          .map(m => {
+            setTraceId(m)
+            m
+          })
+          .async
+          .buffer(10, OverflowStrategy.dropHead)
+          .map { n =>
+            currentTraceId should be (Some(n))
+            currentTraceId
+          }.toMat(Sink.seq)(Keep.both).run()
+
+        val msgs = (1 to 5).map(i => s"msg-$i")
+        msgs.foreach(m => ref ! m)
+
+        ref ! Status.Success("done")
+
+        sink.futureValue.flatten should have size 5
+        sink.futureValue.flatten should contain allElementsOf(msgs)
+      }
+    }
+
+    "graph" in {
+      def broadcastAndMerge[I,O] (flow: Flow[I, O, NotUsed]): Flow[I, O, NotUsed] =
+        Flow.fromGraph[I, O, NotUsed](GraphDSL.create(flow) { implicit builder => flow =>
+          import GraphDSL.Implicits._
+
+          val broadcast = builder.add(Broadcast[I](5))
+          val merge = builder.add(Merge[I](5))
+          def fn = builder.add(Flow[I].async)
+
+          // dummy graph to illustrate, that the element can take several paths
+          broadcast ~> fn ~> merge
+          broadcast ~> fn ~> merge
+          broadcast ~> fn ~> merge
+          broadcast ~> fn ~> merge
+          broadcast ~> fn ~> merge
+                             merge ~> flow
+
+          FlowShape(broadcast.in, flow.out)
+        })
+
+      val nums = List(1,2,3,4,5)
+      val (queue, sink) = Source.queue[Int](nums.size, OverflowStrategy.fail)
+        .via(broadcastAndMerge(Flow.fromFunction((_: Int) => currentTraceId())))
+        .toMat(Sink.seq)(Keep.both)
+        .run()
+
+      inContext("outer") {
+        val a = nums.map { num =>
+          setTraceId(num.toString)
+          queue.offer(num)
+        }.toSeq
+
+        Future.sequence(a).futureValue
+        queue.complete()
+        val result = sink.futureValue
+        // each element is broadcasted and merged 5 times --> expect 5 times size
+        result.flatten should have size  5 * nums.size
+        result.flatten should contain allElementsOf nums.map(_.toString)
+      }
+    }
+
+   /* "throtle" in {
+      //Throtled elements get scheduled on interpreter as runnable invoking asyncCallback
+      //Executor instrumentation will capture context and provide it to callback instrumentation
+
+      implicit val patienceConfig: PatienceConfig = PatienceConfig(
+        timeout = scaled(Span(12, Seconds)),
+        interval = scaled(Span(1, Seconds))
+      )
+
+      val nums = 1 to 1000
+      val res = Source(nums)
+        .map(setCtx)
+        .throttle(100, 1 seconds)
+        .map { i =>
+          currentTraceId() should be (Some(i.toString))
+        }
+        .runWith(Sink.seq)
+      res.futureValue.flatten should contain allElementsOf(nums.map(_.toString))
+    }*/
+
+  }
+
+}


### PR DESCRIPTION
Draft for Akka Streams context propagation

Part of kamon-akka repo due to convinience, can be pulled out to a separate project since it doesnt depend on akka instrumentation.

Takes care of these particular aspect of propagation:
 - in between stages
 - between async islands
 - stage callbacks
 - retaining context when branching into substreams and merging back
 - retaining context when buffering internaly for some stages

Stage propagation is done using connection instrumentation. During stream materialization connections are created for all in-out pairs between stages which contains an element being pushed to the next stage. When a stage pushes downstream, `push` method is instrumented to capture context and store it with connection. `grab` instrumentation will in turn pick up context from connection and apply it to current thread just in time for downstream stage logic to kick in. 

If theres an async boundary between stages, two islands will be materialized, first ending with a `ActorOutputBoundary` stage and next one starting with `BatchingActorInputBoundary`. These two will communicate via publisher-subscriber pair using `OnNext` which will capture context and carry it over.

For async callbacks, invocation will capture call site context and pass a wrapped handler to the interpreter. (`Kamon.withContext(ctx){ handler }`). For cases where callback is invoked before stream is materialized, buffered `Event`s will capture context and `onStart` method is replaced with one which will process all pending events using context from each one.

For StreamOfStreams, sub-sink and sub-source are capturing context from element that triggered their creation which will then get propagated to all produced elements.

Known problems:
Any custom stage which does internal event buffering and reordering should manually buffer elements bundled with context. Instrumentation is provided for `mapAsync` stage, wrapping internal buffer with one which tracks context. From perspective of a processing stage, correct context is available after invoking `grab(inlet)` and in order to carry it, correct one needs to be applied before invoking `push(out, elem)`.

There are pretty ugly reflection parts (even on hot path :/ ) but the idea was to get the pointcuts right first and then optimize, possibly move it to kanela?

Please review, comment and lets see where we can take it from here.
Failing stage combinations super welcome!


Here's a snapshot:
https://bintray.com/kamon-io/snapshots/kamon-akka/1.1.3-a7cdf7c16b479a18ca55b225abb95ce50455b9d8