### PR TITLE
Dispatcher registration leak

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@
 
 
 resolvers += Resolver.bintrayRepo("kamon-io", "snapshots")
-val kamonCore       = "io.kamon" %% "kamon-core"         % "1.1.3"
+val kamonCore       = "io.kamon" %% "kamon-core"         % "1.1.4-783ff3e53ccfae46c213b0cec8be48788d91fbcb"
 val kamonTestkit    = "io.kamon" %% "kamon-testkit"      % "1.1.3"
 val kamonScala      = "io.kamon" %% "kamon-scala-future" % "1.0.0"
 val kamonExecutors  = "io.kamon" %% "kamon-executors"    % "1.0.1"

--- a/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/DispatcherInstrumentation.scala
+++ b/kamon-akka-2.4.x/src/main/scala/kamon/akka/instrumentation/DispatcherInstrumentation.scala
@@ -86,7 +86,7 @@ class DispatcherInstrumentation {
       val additionalTags = Map("actor-system" -> system.name)
       val dispatcherRegistration = Executors.register(dispatcherName, additionalTags, executorService)
 
-      registeredDispatchers.put(dispatcherName, dispatcherRegistration)
+      registeredDispatchers.put(dispatcherName, dispatcherRegistration).foreach(_.cancel())
     }
   }
 
@@ -143,7 +143,7 @@ class DispatcherInstrumentation {
     import lazyExecutor.lookupData
 
     if (lookupData.actorSystem != null) {
-      registeredDispatchers.get(lookupData.dispatcherName).foreach(_.cancel())
+      registeredDispatchers.remove(lookupData.dispatcherName).foreach(_.cancel())
     }
   }
 

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/DispatcherInstrumentation.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/DispatcherInstrumentation.scala
@@ -107,8 +107,7 @@ class DispatcherInstrumentation {
     if(Kamon.filter(Akka.DispatcherFilterName, dispatcherName)) {
       val additionalTags = Map("actor-system" -> system.name)
       val dispatcherRegistration = Executors.register(dispatcherName, additionalTags, executorService)
-
-      registeredDispatchers.put(dispatcherName, dispatcherRegistration)
+      registeredDispatchers.put(dispatcherName, dispatcherRegistration).foreach(_.cancel())
     }
   }
 
@@ -166,7 +165,7 @@ class DispatcherInstrumentation {
     import lazyExecutor.lookupData
 
     if (lookupData.actorSystem != null) {
-      registeredDispatchers.get(lookupData.dispatcherName).foreach(_.cancel())
+      registeredDispatchers.remove(lookupData.dispatcherName).foreach(_.cancel())
     }
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.2"
+version in ThisBuild := "1.1.3-SNAPSHOT"


### PR DESCRIPTION
 Registering a dispatcher with a previously seen name, before shutdown has cleaned registration of a previous one, will leave old registration hanging around, never canceled. 

- When overwriting registration, cancel previous one
- When shutting down dispatcher, cancel and remove registration

Fixes #48 