### PR TITLE
Minor improvements on tracing details

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,14 +33,14 @@ lazy val `kamon-akka` = (project in file("."))
 
 
 lazy val kamonAkka24 = Project("kamon-akka-24", file("kamon-akka-2.4.x"))
-  .settings(Seq(
+  .enablePlugins(JavaAgent)
+  .settings(instrumentationSettings: _*)
+  .settings(
     bintrayPackage := "kamon-akka",
     moduleName := "kamon-akka-2.4",
     scalaVersion := "2.12.1",
     crossScalaVersions := Seq("2.11.8", "2.12.1"),
-    resolvers += Resolver.bintrayRepo("kamon-io", "snapshots")))
-  .settings(aspectJSettings: _*)
-  .settings(
+    resolvers += Resolver.bintrayRepo("kamon-io", "snapshots"),
     libraryDependencies ++=
       compileScope(akkaDependency("actor", `akka-2.4`), kamonCore, kamonScala, kamonExecutors) ++
       providedScope(aspectJ) ++
@@ -48,18 +48,17 @@ lazy val kamonAkka24 = Project("kamon-akka-24", file("kamon-akka-2.4.x"))
       testScope(scalatest, kamonTestkit, akkaDependency("testkit", `akka-2.4`), akkaDependency("slf4j", `akka-2.4`), logbackClassic))
 
 lazy val kamonAkka25 = Project("kamon-akka-25", file("kamon-akka-2.5.x"))
-  .settings(Seq(
-    bintrayPackage := "kamon-akka",
+  .enablePlugins(JavaAgent)
+  .settings(instrumentationSettings: _*)
+  .settings(
+      bintrayPackage := "kamon-akka",
     moduleName := "kamon-akka-2.5",
     scalaVersion := "2.12.1",
     crossScalaVersions := Seq("2.11.8", "2.12.1"),
-    resolvers += Resolver.bintrayRepo("kamon-io", "snapshots")))
-  .settings(aspectJSettings: _*)
-  .settings(
+    resolvers += Resolver.bintrayRepo("kamon-io", "snapshots"),
     libraryDependencies ++=
       compileScope(akkaDependency("actor", `akka-2.5`), kamonCore, kamonScala, kamonExecutors) ++
       providedScope(aspectJ) ++
       optionalScope(logbackClassic) ++
       testScope(scalatest, kamonTestkit, akkaDependency("testkit", `akka-2.5`), akkaDependency("slf4j", `akka-2.5`), logbackClassic))
 
-enableProperCrossScalaVersionTasks

--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,7 @@ lazy val kamonAkka24 = Project("kamon-akka-24", file("kamon-akka-2.4.x"))
     moduleName := "kamon-akka-2.4",
     scalaVersion := "2.12.1",
     crossScalaVersions := Seq("2.11.8", "2.12.1"),
+    kamonUseAspectJ := true,
     resolvers += Resolver.bintrayRepo("kamon-io", "snapshots"),
     libraryDependencies ++=
       compileScope(akkaDependency("actor", `akka-2.4`), kamonCore, kamonScala, kamonExecutors) ++
@@ -51,10 +52,11 @@ lazy val kamonAkka25 = Project("kamon-akka-25", file("kamon-akka-2.5.x"))
   .enablePlugins(JavaAgent)
   .settings(instrumentationSettings: _*)
   .settings(
-      bintrayPackage := "kamon-akka",
+    bintrayPackage := "kamon-akka",
     moduleName := "kamon-akka-2.5",
     scalaVersion := "2.12.1",
     crossScalaVersions := Seq("2.11.8", "2.12.1"),
+    kamonUseAspectJ := true,
     resolvers += Resolver.bintrayRepo("kamon-io", "snapshots"),
     libraryDependencies ++=
       compileScope(akkaDependency("actor", `akka-2.5`), kamonCore, kamonScala, kamonExecutors) ++

--- a/kamon-akka-2.4.x/src/main/resources/reference.conf
+++ b/kamon-akka-2.4.x/src/main/resources/reference.conf
@@ -48,7 +48,7 @@ kamon {
     }
 
     "akka.traced-actor" {
-      includes = [ ]
+      includes = [ "*/user/**", "*/system/sharding**" ]
       excludes = [ ]
     }
   }

--- a/kamon-akka-2.4.x/src/test/resources/application.conf
+++ b/kamon-akka-2.4.x/src/test/resources/application.conf
@@ -81,7 +81,10 @@ kamon {
 
   }
 
-  trace.sampler = "always"
+  trace {
+    tick-interval = 10 milliseconds
+    sampler = "always"
+  }
 
   default-instrument-settings {
     gauge.refresh-interval = 1 hour

--- a/kamon-akka-2.5.x/src/main/resources/reference.conf
+++ b/kamon-akka-2.5.x/src/main/resources/reference.conf
@@ -48,7 +48,7 @@ kamon {
     }
 
     "akka.traced-actor" {
-      includes = [ ]
+      includes = [ "*/user/**", "*/system/sharding**" ]
       excludes = [ ]
     }
   }

--- a/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/CellInfo.scala
+++ b/kamon-akka-2.5.x/src/main/scala/kamon/akka/instrumentation/CellInfo.scala
@@ -42,9 +42,9 @@ object CellInfo {
 
     val (actorOrRouterClass, routeeClass) =
       if(isRouter)
-        (cell.props.routerConfig.getClass, Some(ref.asInstanceOf[RoutedActorRefAccessor].routeeProps.clazz))
+        (cell.props.routerConfig.getClass, Some(ref.asInstanceOf[RoutedActorRefAccessor].routeeProps.actorClass))
       else if (isRoutee)
-        (parent.asInstanceOf[RoutedActorRefAccessor].routerProps.routerConfig.getClass, Some(cell.props.clazz))
+        (parent.asInstanceOf[RoutedActorRefAccessor].routerProps.routerConfig.getClass, Some(cell.props.actorClass))
       else
         (cell.props.actorClass(), None)
 

--- a/kamon-akka-2.5.x/src/test/resources/application.conf
+++ b/kamon-akka-2.5.x/src/test/resources/application.conf
@@ -81,7 +81,10 @@ kamon {
 
   }
 
-  trace.sampler = "always"
+  trace {
+    tick-interval = 10 milliseconds
+    sampler = "always"
+  }
 
   default-instrument-settings {
     gauge.refresh-interval = 1 hour

--- a/kamon-akka-2.5.x/src/test/scala/kamon/akka/instrumentation/MessageTracingSpec.scala
+++ b/kamon-akka-2.5.x/src/test/scala/kamon/akka/instrumentation/MessageTracingSpec.scala
@@ -20,17 +20,20 @@ class MessageTracingSpec extends TestKit(ActorSystem("MessageTracing")) with Wor
     "skip filtered out actors" in {
       val traced = system.actorOf(Props[TracingTestActor], "traced-probe-1")
       val nonTraced = system.actorOf(Props[TracingTestActor], "filteredout")
-      nonTraced ! "ping"
-      expectMsg("pong")
 
-      traced ! "ping"
-      expectMsg("pong")
+      Kamon.withSpan(Kamon.buildSpan("outer").start()) {
+        nonTraced ! "ping"
+        expectMsg("pong")
+
+        traced ! "ping"
+        expectMsg("pong")
+      }
 
       eventually(timeout(2 seconds)) {
         val span = reporter.nextSpan().value
         val spanTags = stringTag(span) _
+        span.operationName shouldBe("TracingTestActor ! String")
         spanTags("component") shouldBe "akka.actor"
-        span.operationName shouldBe("TracingTestActor: String")
         spanTags("akka.actor.path") shouldNot include ("filteredout")
         spanTags("akka.actor.path") should be ("MessageTracing/user/traced-probe-1")
       }
@@ -38,13 +41,15 @@ class MessageTracingSpec extends TestKit(ActorSystem("MessageTracing")) with Wor
 
     "construct span for traced actors" in {
       val traced = system.actorOf(Props[TracingTestActor], "traced")
-      traced ! "ping"
-      expectMsg("pong")
+      Kamon.withSpan(Kamon.buildSpan("outer").start()) {
+        traced ! "ping"
+        expectMsg("pong")
+      }
 
       eventually(timeout(2 seconds)) {
         val span = reporter.nextSpan().value
         val spanTags = stringTag(span) _
-        span.operationName shouldBe("TracingTestActor: String")
+        span.operationName shouldBe("TracingTestActor ! String")
         spanTags("component") shouldBe "akka.actor"
         spanTags("akka.system") shouldBe "MessageTracing"
         spanTags("akka.actor.path") shouldBe "MessageTracing/user/traced"
@@ -57,14 +62,16 @@ class MessageTracingSpec extends TestKit(ActorSystem("MessageTracing")) with Wor
       val first = system.actorOf(Props[TracingTestActor], "traced-first")
       val second = system.actorOf(Props[TracingTestActor], "traced-second")
 
-      first ! second
-      expectMsg("pong")
+      Kamon.withSpan(Kamon.buildSpan("outer").start()) {
+        first ! second
+        expectMsg("pong")
+      }
 
       // Span for the first actor message
       val firstSpanID = eventually(timeout(2 seconds)) {
         val span = reporter.nextSpan().value
         val spanTags = stringTag(span) _
-        span.operationName should include("TracingTestActor: ")
+        span.operationName should include("TracingTestActor !")
         spanTags("component") shouldBe "akka.actor"
         spanTags("akka.system") shouldBe "MessageTracing"
         spanTags("akka.actor.path") shouldBe "MessageTracing/user/traced-first"
@@ -79,7 +86,7 @@ class MessageTracingSpec extends TestKit(ActorSystem("MessageTracing")) with Wor
         val span = reporter.nextSpan().value
         val spanTags = stringTag(span) _
         span.context.parentID shouldBe firstSpanID
-        span.operationName should include("TracingTestActor: String")
+        span.operationName should include("TracingTestActor ! String")
         spanTags("component") shouldBe "akka.actor"
         spanTags("akka.system") shouldBe "MessageTracing"
         spanTags("akka.actor.path") shouldBe "MessageTracing/user/traced-second"
@@ -93,14 +100,16 @@ class MessageTracingSpec extends TestKit(ActorSystem("MessageTracing")) with Wor
       val nonInstrumented = system.actorOf(Props[TracingTestActor], "filteredout-middle")
       val last = system.actorOf(Props[TracingTestActor], "traced-chain-last")
 
-      first ! (nonInstrumented, last)
-      expectMsg("pong")
+      Kamon.withSpan(Kamon.buildSpan("outer").start()) {
+        first ! (nonInstrumented, last)
+        expectMsg("pong")
+      }
 
       // Span for the first actor message
       val firstSpanID = eventually(timeout(2 seconds)) {
         val span = reporter.nextSpan().value
         val spanTags = stringTag(span) _
-        span.operationName shouldBe("TracingTestActor: Tuple2")
+        span.operationName shouldBe("TracingTestActor ! Tuple2")
         spanTags("component") shouldBe "akka.actor"
         spanTags("akka.system") shouldBe "MessageTracing"
         spanTags("akka.actor.path") shouldBe "MessageTracing/user/traced-chain-first"
@@ -115,7 +124,7 @@ class MessageTracingSpec extends TestKit(ActorSystem("MessageTracing")) with Wor
         val span = reporter.nextSpan().value
         val spanTags = stringTag(span) _
         span.context.parentID shouldBe firstSpanID
-        span.operationName shouldBe("TracingTestActor: String")
+        span.operationName shouldBe("TracingTestActor ! String")
         spanTags("component") shouldBe "akka.actor"
         spanTags("akka.system") shouldBe "MessageTracing"
         spanTags("akka.actor.path") shouldBe "MessageTracing/user/traced-chain-last"
@@ -128,8 +137,10 @@ class MessageTracingSpec extends TestKit(ActorSystem("MessageTracing")) with Wor
       val routee = system.actorOf(Props[TracingTestActor],"traced-routee-one")
       val router = system.actorOf(RoundRobinGroup(Vector(routee.path.toStringWithoutAddress)).props(), "nontraced-group-router")
 
-      router ! "ping"
-      expectMsg("pong")
+      Kamon.withSpan(Kamon.buildSpan("outer").start()) {
+        router ! "ping"
+        expectMsg("pong")
+      }
 
       eventually(timeout(2 seconds)) {
         val spanTags = stringTag(reporter.nextSpan().value) _
@@ -142,8 +153,10 @@ class MessageTracingSpec extends TestKit(ActorSystem("MessageTracing")) with Wor
     "create actor message spans when behind a pool router" in {
       val router = system.actorOf(Props[TracingTestActor].withRouter(RoundRobinPool(2)), "traced-pool-router")
 
-      router ! "ping-and-wait"
-      expectMsg("pong")
+      Kamon.withSpan(Kamon.buildSpan("outer").start()) {
+        router ! "ping-and-wait"
+        expectMsg("pong")
+      }
 
       eventually(timeout(2 seconds)) {
         val spanTags = stringTag(reporter.nextSpan().value) _

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,1 @@
-lazy val root: Project = project.in(file(".")).dependsOn(latestSbtUmbrella)
-lazy val latestSbtUmbrella = uri("git://github.com/kamon-io/kamon-sbt-umbrella.git")
+lazy val root = project in file(".") dependsOn(RootProject(uri("git://github.com/kamon-io/kamon-sbt-umbrella.git#kamon-1.x")))


### PR DESCRIPTION
There are 3 specific improvements brought by this PR:
  - Spans will only be created if there is a current trace happening. This ensures that we will not be generating trillions of Spans because of scheduled actions and receive timeouts and so on.
  - Do a best effort to get the simple class name for both actor classes and message classes that will be tagging the message spans.
  - Ensure that the proper class name for actors is used instead of `TypedCreatorFunctionConsumer`.

  